### PR TITLE
Improve reasoning engine test coverage

### DIFF
--- a/force-app/main/default/classes/SentinelReasoningEngine.cls
+++ b/force-app/main/default/classes/SentinelReasoningEngine.cls
@@ -1,6 +1,7 @@
 public without sharing class SentinelReasoningEngine {
     private static final Decimal MIN_CONFIDENCE = 0.85;
 
+    @TestVisible
     private static Decimal getConfidenceThreshold(Sentinel_AI_Settings__c settings) {
         if (settings == null || settings.Confidence_Threshold__c == null) {
             return MIN_CONFIDENCE;
@@ -77,6 +78,7 @@ public without sharing class SentinelReasoningEngine {
         return policy;
     }
 
+    @TestVisible
     private static String buildSafeExplanation(Compliance_Policy__mdt policy, Sentinel_Compliance_Graph__b node, PredictionResult einsteinResult, Sentinel_AI_Settings__c settings) {
         Decimal confidenceThreshold = getConfidenceThreshold(settings);
         String prefix = einsteinResult.confidence < confidenceThreshold ? '[REVIEW REQUIRED] ' : '';

--- a/force-app/main/default/classes/SentinelReasoningEngineTest.cls
+++ b/force-app/main/default/classes/SentinelReasoningEngineTest.cls
@@ -174,4 +174,59 @@ private class SentinelReasoningEngineTest {
         System.assertEquals(false, result.isViolation, 'Should indicate no violation');
         System.assertEquals(false, result.requiresHumanReview, 'Should not require human review');
     }
+
+    @IsTest
+    static void testGetConfidenceThreshold_Defaults() {
+        Test.startTest();
+        Decimal thresholdWhenNull = SentinelReasoningEngine.getConfidenceThreshold(null);
+
+        Sentinel_AI_Settings__c settingsWithNullThreshold = new Sentinel_AI_Settings__c(
+            Confidence_Threshold__c = null
+        );
+        Decimal thresholdWhenSettingMissing = SentinelReasoningEngine.getConfidenceThreshold(settingsWithNullThreshold);
+        Test.stopTest();
+
+        System.assertEquals(0.85, thresholdWhenNull, 'Should fall back to minimum confidence when settings are missing');
+        System.assertEquals(
+            0.85,
+            thresholdWhenSettingMissing,
+            'Should fall back to minimum confidence when threshold is not defined'
+        );
+    }
+
+    @IsTest
+    static void testGetConfidenceThreshold_CustomValue() {
+        Test.startTest();
+        Sentinel_AI_Settings__c settings = new Sentinel_AI_Settings__c(
+            Confidence_Threshold__c = 0.92
+        );
+        Decimal threshold = SentinelReasoningEngine.getConfidenceThreshold(settings);
+        Test.stopTest();
+
+        System.assertEquals(0.92, threshold, 'Should respect custom confidence threshold in settings');
+    }
+
+    @IsTest
+    static void testBuildSafeExplanation_AddsReviewPrefixWhenBelowThreshold() {
+        Compliance_Policy__mdt policy = new Compliance_Policy__mdt(
+            Policy_Description__c = 'Policy description',
+            Legal_Citation__c = 'CIT-123',
+            Remediation_Steps__c = 'Remediate quickly'
+        );
+        Sentinel_Compliance_Graph__b node = new Sentinel_Compliance_Graph__b(
+            Entity_Type__c = 'FLOW',
+            Entity_Record_Id__c = 'Flow123',
+            Risk_Score__c = 9
+        );
+        SentinelReasoningEngine.PredictionResult prediction = new SentinelReasoningEngine.PredictionResult(true, 0.5, 'POLICY');
+        Sentinel_AI_Settings__c settings = new Sentinel_AI_Settings__c(Confidence_Threshold__c = 0.75);
+
+        Test.startTest();
+        String explanation = SentinelReasoningEngine.buildSafeExplanation(policy, node, prediction, settings);
+        Test.stopTest();
+
+        System.assert(explanation.startsWith('[REVIEW REQUIRED] '), 'Explanation should include review prefix when below threshold');
+        System.assert(explanation.contains('Flow123'), 'Explanation should include entity record id');
+        System.assert(explanation.contains('Policy description'), 'Explanation should reference policy description');
+    }
 }


### PR DESCRIPTION
## Summary
- expose confidence threshold and explanation helpers for direct unit testing
- add tests covering confidence defaults, custom thresholds, and review prefix behavior in explanations

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695c318c8c80832383cb62942cc5e8db)