### PR TITLE
docs: recover P1 completed backlog documentation

### DIFF
--- a/docs/plans/P1_COMPLETED_BACKLOG.md
+++ b/docs/plans/P1_COMPLETED_BACKLOG.md
@@ -1,0 +1,736 @@
+# P1 Completed Backlog - AppExchange Readiness
+
+**Last Updated:** 2026-01-13
+**Status:** 91.7% Complete (11/12 items)
+**Target:** AppExchange Security Review Submission
+
+---
+
+## Summary
+
+| Category | Completed | Total | Status |
+|----------|-----------|-------|--------|
+| Input Validation | 3 | 3 | ✅ Done |
+| USER_MODE Enforcement | 4 | 4 | ✅ Done |
+| Trigger Recursion Guards | 3 | 3 | ✅ Done |
+| Bulk Tests (200+ records) | 4 | 4 | ✅ Done |
+| Framework Validation | 1 | 2 | ⏳ 1 Pending |
+| **TOTAL** | **11** | **12** | **91.7%** |
+
+---
+
+## Completed Items
+
+### PROM-001: Input Validation - PrometheionGraphIndexer
+
+| Field | Value |
+|-------|-------|
+| **ID** | PROM-001 |
+| **Type** | Security / Input Validation |
+| **Priority** | P1 - AppExchange Blocking |
+| **Status** | ✅ Complete |
+| **Completed** | 2026-01-12 |
+| **Owner** | Cursor |
+
+**Description:**
+Add input validation to PrometheionGraphIndexer.cls to prevent injection attacks and ensure data integrity.
+
+**Files Changed:**
+- `force-app/main/default/classes/PrometheionGraphIndexer.cls` (lines 5-18)
+
+**Implementation:**
+```apex
+if (String.isBlank(entityType)) {
+    throw new IllegalArgumentException('entityType cannot be null or empty');
+}
+if (String.isBlank(entityId)) {
+    throw new IllegalArgumentException('entityId cannot be null or empty');
+}
+if (!SUPPORTED_FRAMEWORKS.contains(framework)) {
+    throw new IllegalArgumentException('Unsupported framework: ' + framework);
+}
+```
+
+**Acceptance Criteria:**
+- [x] Null/empty string validation for entityType
+- [x] Null/empty string validation for entityId
+- [x] Framework validation against supported list
+- [x] Throws IllegalArgumentException with descriptive message
+
+---
+
+### PROM-002: Input Validation - PerformanceAlertPublisher
+
+| Field | Value |
+|-------|-------|
+| **ID** | PROM-002 |
+| **Type** | Security / Input Validation |
+| **Priority** | P1 - AppExchange Blocking |
+| **Status** | ✅ Complete |
+| **Completed** | 2026-01-12 |
+| **Owner** | Cursor |
+
+**Description:**
+Add input validation to PerformanceAlertPublisher.cls for metric, value, and threshold parameters.
+
+**Files Changed:**
+- `force-app/main/default/classes/PerformanceAlertPublisher.cls` (lines 22-31)
+
+**Implementation:**
+```apex
+if (String.isBlank(metric)) {
+    throw new IllegalArgumentException('metric cannot be null or empty');
+}
+if (value == null || value < 0) {
+    throw new IllegalArgumentException('value must be a non-negative number');
+}
+if (threshold == null || threshold < 0) {
+    throw new IllegalArgumentException('threshold must be a non-negative number');
+}
+```
+
+**Acceptance Criteria:**
+- [x] Null/empty string validation for metric
+- [x] Non-negative validation for value
+- [x] Non-negative validation for threshold
+- [x] Throws IllegalArgumentException with descriptive message
+
+---
+
+### PROM-003: Input Validation - FlowExecutionLogger
+
+| Field | Value |
+|-------|-------|
+| **ID** | PROM-003 |
+| **Type** | Security / Input Validation |
+| **Priority** | P1 - AppExchange Blocking |
+| **Status** | ✅ Complete |
+| **Completed** | 2026-01-12 |
+| **Owner** | Cursor |
+
+**Description:**
+Add CRUD/FLS validation and parameter validation to FlowExecutionLogger.cls.
+
+**Files Changed:**
+- `force-app/main/default/classes/FlowExecutionLogger.cls` (lines 13-19)
+
+**Implementation:**
+```apex
+// CRUD/FLS check before DML
+if (!Schema.sObjectType.Flow_Execution__c.isCreateable()) {
+    throw new SecurityException('Insufficient privileges to create Flow_Execution__c');
+}
+// Parameters marked @required in method signature
+```
+
+**Acceptance Criteria:**
+- [x] CRUD check for Flow_Execution__c create
+- [x] FLS validation for required fields
+- [x] Parameters marked as @required
+- [x] SecurityException thrown for insufficient privileges
+
+---
+
+### PROM-004: USER_MODE - PrometheionComplianceScorer
+
+| Field | Value |
+|-------|-------|
+| **ID** | PROM-004 |
+| **Type** | Security / SOQL Enforcement |
+| **Priority** | P1 - AppExchange Blocking |
+| **Status** | ✅ Complete |
+| **Completed** | 2026-01-12 |
+| **Owner** | Cursor |
+
+**Description:**
+Add WITH USER_MODE to all SOQL queries in PrometheionComplianceScorer.cls to enforce field-level security.
+
+**Files Changed:**
+- `force-app/main/default/classes/PrometheionComplianceScorer.cls` (lines 170, 181, 189, 257, 270, 311, 475)
+
+**Implementation:**
+```apex
+List<Compliance_Score__c> scores = [
+    SELECT Id, Risk_Score__c, Framework_Scores__c
+    FROM Compliance_Score__c
+    WHERE Org_ID__c = :orgId
+    WITH USER_MODE
+];
+```
+
+**Acceptance Criteria:**
+- [x] WITH USER_MODE on line 170 query
+- [x] WITH USER_MODE on line 181 query
+- [x] WITH USER_MODE on line 189 query
+- [x] WITH USER_MODE on line 257 query
+- [x] WITH USER_MODE on line 270 query
+- [x] WITH USER_MODE on line 311 query
+- [x] WITH USER_MODE on line 475 query
+
+---
+
+### PROM-005: USER_MODE - PrometheionGraphIndexer
+
+| Field | Value |
+|-------|-------|
+| **ID** | PROM-005 |
+| **Type** | Security / SOQL Enforcement |
+| **Priority** | P1 - AppExchange Blocking |
+| **Status** | ✅ Complete |
+| **Completed** | 2026-01-12 |
+| **Owner** | Cursor |
+
+**Description:**
+Add WITH USER_MODE to SOQL queries for PermissionSet and FlowDefinitionView in PrometheionGraphIndexer.cls.
+
+**Files Changed:**
+- `force-app/main/default/classes/PrometheionGraphIndexer.cls` (lines 79, 100)
+
+**Implementation:**
+```apex
+List<PermissionSet> permSets = [
+    SELECT Id, Name, Label
+    FROM PermissionSet
+    WHERE IsOwnedByProfile = false
+    WITH USER_MODE
+];
+
+List<FlowDefinitionView> flows = [
+    SELECT Id, ApiName, Label, ProcessType
+    FROM FlowDefinitionView
+    WHERE IsActive = true
+    WITH USER_MODE
+];
+```
+
+**Acceptance Criteria:**
+- [x] WITH USER_MODE on PermissionSet query (line 79)
+- [x] WITH USER_MODE on FlowDefinitionView query (line 100)
+
+---
+
+### PROM-006: USER_MODE - EvidenceCollectionService
+
+| Field | Value |
+|-------|-------|
+| **ID** | PROM-006 |
+| **Type** | Security / SOQL Enforcement |
+| **Priority** | P1 - AppExchange Blocking |
+| **Status** | ✅ Complete |
+| **Completed** | 2026-01-12 |
+| **Owner** | Cursor |
+
+**Description:**
+Add WITH SECURITY_ENFORCED to PermissionSet query in EvidenceCollectionService.cls.
+
+**Files Changed:**
+- `force-app/main/default/classes/EvidenceCollectionService.cls` (line 123)
+
+**Implementation:**
+```apex
+List<PermissionSet> permSets = [
+    SELECT Id, Name, Label, Description
+    FROM PermissionSet
+    WHERE Id IN :permSetIds
+    WITH SECURITY_ENFORCED
+];
+```
+
+**Acceptance Criteria:**
+- [x] WITH SECURITY_ENFORCED on PermissionSet query (line 123)
+- [x] FLS enforced for all selected fields
+
+---
+
+### PROM-007: USER_MODE - ComplianceDashboardController
+
+| Field | Value |
+|-------|-------|
+| **ID** | PROM-007 |
+| **Type** | Security / SOQL Enforcement |
+| **Priority** | P1 - AppExchange Blocking |
+| **Status** | ✅ Complete |
+| **Completed** | 2026-01-12 |
+| **Owner** | Cursor |
+
+**Description:**
+Add WITH SECURITY_ENFORCED to Gap and Evidence queries in ComplianceDashboardController.cls.
+
+**Files Changed:**
+- `force-app/main/default/classes/ComplianceDashboardController.cls` (lines 49, 58, 88, 97)
+
+**Implementation:**
+```apex
+List<Compliance_Gap__c> gaps = [
+    SELECT Id, Name, Severity__c, Status__c, Framework__c
+    FROM Compliance_Gap__c
+    WHERE Status__c != 'Resolved'
+    WITH SECURITY_ENFORCED
+];
+
+List<Compliance_Evidence__c> evidence = [
+    SELECT Id, Name, Type__c, Gap__c
+    FROM Compliance_Evidence__c
+    WHERE Gap__c IN :gapIds
+    WITH SECURITY_ENFORCED
+];
+```
+
+**Acceptance Criteria:**
+- [x] WITH SECURITY_ENFORCED on Gap query (line 49)
+- [x] WITH SECURITY_ENFORCED on Gap query (line 58)
+- [x] WITH SECURITY_ENFORCED on Evidence query (line 88)
+- [x] WITH SECURITY_ENFORCED on Evidence query (line 97)
+
+---
+
+### PROM-008: Trigger Guard - PerformanceAlertEventTrigger
+
+| Field | Value |
+|-------|-------|
+| **ID** | PROM-008 |
+| **Type** | Security / Trigger Safety |
+| **Priority** | P1 - AppExchange Blocking |
+| **Status** | ✅ Complete |
+| **Completed** | 2026-01-13 |
+| **Owner** | Claude |
+| **Commit** | 75d0714 |
+
+**Description:**
+Add TriggerRecursionGuard to PerformanceAlertEventTrigger to prevent infinite loops during DML operations.
+
+**Files Changed:**
+- `force-app/main/default/triggers/PerformanceAlertEventTrigger.trigger`
+
+**Implementation:**
+```apex
+trigger PerformanceAlertEventTrigger on Performance_Alert__e (after insert) {
+    if (TriggerRecursionGuard.isFirstRun('PerformanceAlertEventTrigger')) {
+        try {
+            PerformanceAlertEventHandler.handleAfterInsert(Trigger.new);
+        } finally {
+            TriggerRecursionGuard.reset('PerformanceAlertEventTrigger');
+        }
+    }
+}
+```
+
+**Acceptance Criteria:**
+- [x] TriggerRecursionGuard.isFirstRun() check
+- [x] try/finally block for guaranteed reset
+- [x] TriggerRecursionGuard.reset() in finally
+- [x] Prevents recursive trigger execution
+
+---
+
+### PROM-009: Trigger Guard - PrometheionPCIAccessAlertTrigger
+
+| Field | Value |
+|-------|-------|
+| **ID** | PROM-009 |
+| **Type** | Security / Trigger Safety |
+| **Priority** | P1 - AppExchange Blocking |
+| **Status** | ✅ Complete |
+| **Completed** | 2026-01-13 |
+| **Owner** | Claude |
+| **Commit** | 75d0714 |
+
+**Description:**
+Add TriggerRecursionGuard to PrometheionPCIAccessAlertTrigger to prevent infinite loops when handling PCI access events.
+
+**Files Changed:**
+- `force-app/main/default/triggers/PrometheionPCIAccessAlertTrigger.trigger`
+
+**Implementation:**
+```apex
+trigger PrometheionPCIAccessAlertTrigger on PCI_Access_Event__e (after insert) {
+    if (TriggerRecursionGuard.isFirstRun('PrometheionPCIAccessAlertTrigger')) {
+        try {
+            PrometheionPCIAccessAlertHandler.handleAfterInsert(Trigger.new);
+        } finally {
+            TriggerRecursionGuard.reset('PrometheionPCIAccessAlertTrigger');
+        }
+    }
+}
+```
+
+**Acceptance Criteria:**
+- [x] TriggerRecursionGuard.isFirstRun() check
+- [x] try/finally block for guaranteed reset
+- [x] TriggerRecursionGuard.reset() in finally
+- [x] Prevents recursive trigger execution
+
+---
+
+### PROM-010: Trigger Guard - PrometheionEventCaptureTrigger
+
+| Field | Value |
+|-------|-------|
+| **ID** | PROM-010 |
+| **Type** | Security / Trigger Safety |
+| **Priority** | P1 - AppExchange Blocking |
+| **Status** | ✅ Complete |
+| **Completed** | 2026-01-13 |
+| **Owner** | Claude |
+| **Commit** | 75d0714 |
+
+**Description:**
+Add TriggerRecursionGuard to PrometheionEventCaptureTrigger to prevent infinite loops during event processing.
+
+**Files Changed:**
+- `force-app/main/default/triggers/PrometheionEventCaptureTrigger.trigger`
+
+**Implementation:**
+```apex
+trigger PrometheionEventCaptureTrigger on Prometheion_Event__e (after insert) {
+    if (TriggerRecursionGuard.isFirstRun('PrometheionEventCaptureTrigger')) {
+        try {
+            PrometheionEventProcessor.processEvents(Trigger.new);
+        } finally {
+            TriggerRecursionGuard.reset('PrometheionEventCaptureTrigger');
+        }
+    }
+}
+```
+
+**Acceptance Criteria:**
+- [x] TriggerRecursionGuard.isFirstRun() check
+- [x] try/finally block for guaranteed reset
+- [x] TriggerRecursionGuard.reset() in finally
+- [x] Prevents recursive trigger execution
+
+---
+
+### PROM-011: Bulk Tests - PrometheionComplianceScorerTest
+
+| Field | Value |
+|-------|-------|
+| **ID** | PROM-011 |
+| **Type** | Testing / Bulk Operations |
+| **Priority** | P1 - AppExchange Blocking |
+| **Status** | ✅ Complete |
+| **Completed** | 2026-01-12 |
+| **Owner** | Cursor |
+
+**Description:**
+Verify bulk test coverage with 200+ records for PrometheionComplianceScorerTest.cls.
+
+**Files Changed:**
+- `force-app/main/default/classes/PrometheionComplianceScorerTest.cls`
+
+**Implementation:**
+```apex
+@IsTest
+static void testBulkProcessing_250Records() {
+    List<Compliance_Score__c> scores = new List<Compliance_Score__c>();
+    for (Integer i = 0; i < 250; i++) {
+        scores.add(new Compliance_Score__c(
+            Org_ID__c = 'org-' + i,
+            Risk_Score__c = Math.mod(i, 100)
+        ));
+    }
+    insert scores;
+
+    Test.startTest();
+    PrometheionComplianceScorer.calculateReadinessScore();
+    Test.stopTest();
+
+    System.assertEquals(250, [SELECT COUNT() FROM Compliance_Score__c]);
+}
+```
+
+**Acceptance Criteria:**
+- [x] Test creates 250+ records
+- [x] Bulk insert successful
+- [x] calculateReadinessScore() handles bulk
+- [x] No governor limit exceptions
+- [x] Assertions verify bulk processing
+
+---
+
+### PROM-012: Bulk Tests - PrometheionGraphIndexerTest
+
+| Field | Value |
+|-------|-------|
+| **ID** | PROM-012 |
+| **Type** | Testing / Bulk Operations |
+| **Priority** | P1 - AppExchange Blocking |
+| **Status** | ✅ Complete |
+| **Completed** | 2026-01-12 |
+| **Owner** | Cursor |
+
+**Description:**
+Verify bulk test coverage with 200+ records for PrometheionGraphIndexerTest.cls.
+
+**Files Changed:**
+- `force-app/main/default/classes/PrometheionGraphIndexerTest.cls`
+
+**Implementation:**
+```apex
+@IsTest
+static void testBulkIndexing_200Records() {
+    List<Prometheion_Event__e> events = new List<Prometheion_Event__e>();
+    for (Integer i = 0; i < 200; i++) {
+        events.add(new Prometheion_Event__e(
+            Entity_Type__c = 'PermissionSet',
+            Entity_Id__c = '0PS' + String.valueOf(i).leftPad(15, '0'),
+            Framework__c = 'SOC2'
+        ));
+    }
+
+    Test.startTest();
+    EventBus.publish(events);
+    Test.stopTest();
+
+    // Verify indexing completed
+}
+```
+
+**Acceptance Criteria:**
+- [x] Test creates 200+ events
+- [x] Bulk publish successful
+- [x] Graph indexing handles bulk
+- [x] No governor limit exceptions
+
+---
+
+### PROM-013: Bulk Tests - EvidenceCollectionServiceTest
+
+| Field | Value |
+|-------|-------|
+| **ID** | PROM-013 |
+| **Type** | Testing / Bulk Operations |
+| **Priority** | P1 - AppExchange Blocking |
+| **Status** | ✅ Complete |
+| **Completed** | 2026-01-13 |
+| **Owner** | Claude |
+| **Commit** | 75d0714 |
+
+**Description:**
+Add bulk test coverage with 200+ records for EvidenceCollectionServiceTest.cls.
+
+**Files Changed:**
+- `force-app/main/default/classes/EvidenceCollectionServiceTest.cls` (+56 lines)
+
+**Implementation:**
+```apex
+@IsTest
+static void testCollectEvidence_Bulk200Records() {
+    List<Compliance_Gap__c> gaps = new List<Compliance_Gap__c>();
+    for (Integer i = 0; i < 200; i++) {
+        gaps.add(new Compliance_Gap__c(
+            Name = 'Gap-' + i,
+            Severity__c = 'Medium',
+            Framework__c = 'HIPAA'
+        ));
+    }
+    insert gaps;
+
+    Test.startTest();
+    EvidenceCollectionService.collectEvidenceForGaps(gaps);
+    Test.stopTest();
+
+    List<Compliance_Evidence__c> evidence = [
+        SELECT Id FROM Compliance_Evidence__c
+    ];
+    System.assert(evidence.size() >= 200, 'Expected 200+ evidence records');
+}
+
+@IsTest
+static void testCollectEvidence_BulkInsertVerification() {
+    // Additional bulk verification test
+}
+```
+
+**Acceptance Criteria:**
+- [x] testCollectEvidence_Bulk200Records method added
+- [x] testCollectEvidence_BulkInsertVerification method added
+- [x] 200+ gap records created
+- [x] Evidence collection handles bulk
+- [x] No governor limit exceptions
+
+---
+
+### PROM-014: Bulk Tests - PerformanceAlertPublisherTest
+
+| Field | Value |
+|-------|-------|
+| **ID** | PROM-014 |
+| **Type** | Testing / Bulk Operations |
+| **Priority** | P1 - AppExchange Blocking |
+| **Status** | ✅ Complete |
+| **Completed** | 2026-01-13 |
+| **Owner** | Claude |
+| **Commit** | 75d0714 |
+
+**Description:**
+Add bulk test coverage with 200+ records for PerformanceAlertPublisherTest.cls.
+
+**Files Changed:**
+- `force-app/main/default/classes/PerformanceAlertPublisherTest.cls` (+63 lines)
+
+**Implementation:**
+```apex
+@IsTest
+static void testPublishBulk200Alerts() {
+    List<Performance_Alert__e> alerts = new List<Performance_Alert__e>();
+    for (Integer i = 0; i < 200; i++) {
+        alerts.add(new Performance_Alert__e(
+            Metric__c = 'CPU_TIME',
+            Value__c = 5000 + i,
+            Threshold__c = 10000
+        ));
+    }
+
+    Test.startTest();
+    List<Database.SaveResult> results = EventBus.publish(alerts);
+    Test.stopTest();
+
+    Integer successCount = 0;
+    for (Database.SaveResult sr : results) {
+        if (sr.isSuccess()) successCount++;
+    }
+    System.assertEquals(200, successCount, 'Expected 200 successful publishes');
+}
+
+@IsTest
+static void testPublishBulkWithMixedMetrics() {
+    // Test with varied metric types
+}
+```
+
+**Acceptance Criteria:**
+- [x] testPublishBulk200Alerts method added
+- [x] testPublishBulkWithMixedMetrics method added
+- [x] 200 alert events created
+- [x] EventBus.publish handles bulk
+- [x] All 200 publishes successful
+- [x] No governor limit exceptions
+
+---
+
+### PROM-015: Framework Validation Constant
+
+| Field | Value |
+|-------|-------|
+| **ID** | PROM-015 |
+| **Type** | Code Quality / Validation |
+| **Priority** | P1 - AppExchange Blocking |
+| **Status** | ✅ Complete |
+| **Completed** | 2026-01-12 |
+| **Owner** | Cursor |
+
+**Description:**
+Create SUPPORTED_FRAMEWORKS constant and isValidFramework() method in PrometheionConstants.cls.
+
+**Files Changed:**
+- `force-app/main/default/classes/PrometheionConstants.cls`
+
+**Implementation:**
+```apex
+public class PrometheionConstants {
+    public static final Set<String> SUPPORTED_FRAMEWORKS = new Set<String>{
+        'HIPAA', 'SOC2', 'NIST', 'FedRAMP', 'GDPR', 'SOX',
+        'PCI-DSS', 'CCPA', 'GLBA', 'ISO27001'
+    };
+
+    public static Boolean isValidFramework(String framework) {
+        return SUPPORTED_FRAMEWORKS.contains(framework);
+    }
+
+    public static void validateFramework(String framework) {
+        if (!isValidFramework(framework)) {
+            throw new IllegalArgumentException(
+                'Unsupported framework: ' + framework +
+                '. Supported: ' + String.join(new List<String>(SUPPORTED_FRAMEWORKS), ', ')
+            );
+        }
+    }
+}
+```
+
+**Acceptance Criteria:**
+- [x] SUPPORTED_FRAMEWORKS constant created
+- [x] All 10 frameworks included
+- [x] isValidFramework() method implemented
+- [x] validateFramework() method with exception
+
+---
+
+## Pending Items (1 Remaining)
+
+### PROM-016: Framework Validation - Service Classes
+
+| Field | Value |
+|-------|-------|
+| **ID** | PROM-016 |
+| **Type** | Code Quality / Validation |
+| **Priority** | P1 - AppExchange Blocking |
+| **Status** | ⏳ Pending |
+| **Estimated Effort** | 1-2 days |
+| **Owner** | TBD |
+
+**Description:**
+Add framework validation using PrometheionConstants.isValidFramework() to all service classes that accept framework parameter.
+
+**Files to Update:**
+- `PrometheionComplianceScorer.cls`
+- `EvidenceCollectionService.cls`
+- `ComplianceFrameworkService.cls`
+- `PrometheionRealtimeMonitor.cls`
+- Framework-specific services (HIPAA, SOC2, GDPR, etc.)
+
+**Implementation Pattern:**
+```apex
+public static void processForFramework(String framework) {
+    PrometheionConstants.validateFramework(framework);
+    // ... rest of method
+}
+```
+
+**Acceptance Criteria:**
+- [ ] All public methods accepting framework parameter validate input
+- [ ] Uses PrometheionConstants.validateFramework()
+- [ ] IllegalArgumentException thrown for invalid frameworks
+- [ ] Test coverage for validation paths
+
+---
+
+## Completion Timeline
+
+| Date | Items Completed | Cumulative |
+|------|-----------------|------------|
+| 2026-01-12 | PROM-001 to PROM-007, PROM-011, PROM-012, PROM-015 | 10/16 |
+| 2026-01-13 | PROM-008 to PROM-010, PROM-013, PROM-014 | 15/16 |
+| TBD | PROM-016 | 16/16 |
+
+---
+
+## Related Commits
+
+| Commit | Date | Description |
+|--------|------|-------------|
+| `75d0714` | 2026-01-13 | feat: add trigger recursion guards and bulk tests (200+ records) |
+| `2207b2c` | 2026-01-13 | docs: update tracking docs with completed P1 items |
+| `1b5f647` | 2026-01-12 | feat: add compliance report generator and security improvements |
+
+---
+
+## AppExchange Submission Checklist
+
+Based on completed P1 items:
+
+- [x] **Security Review - Input Validation**: All user inputs validated
+- [x] **Security Review - SOQL Injection**: WITH USER_MODE/SECURITY_ENFORCED on all queries
+- [x] **Security Review - CRUD/FLS**: Field-level security enforced
+- [x] **Security Review - Trigger Safety**: Recursion guards on all triggers
+- [x] **Performance - Bulk Testing**: 200+ record tests for all major services
+- [ ] **Code Quality - Framework Validation**: Consistent validation across services
+
+**Status:** Ready for submission after PROM-016 completion
+
+---
+
+*Document Version: 1.0*
+*Created: 2026-01-13*
+*Project: Prometheion v3.0*


### PR DESCRIPTION
Recovered valuable documentation from dangling commit dc91706.

This file documents all 15 completed P1 items for AppExchange readiness tracking:
- 3 input validation items (PROM-001 to PROM-003)
- 4 USER_MODE enforcement items (PROM-004 to PROM-007)
- 3 trigger recursion guards (PROM-008 to PROM-010)
- 4 bulk tests 200+ records (PROM-011 to PROM-014)
- 1 framework validation constant (PROM-015)

736 lines of comprehensive documentation that was accidentally lost.