### PR TITLE
refactor(security): complete Spring '26 assert and lwc:if migration

### DIFF
--- a/force-app/main/default/classes/AccessReviewSchedulerTest.cls
+++ b/force-app/main/default/classes/AccessReviewSchedulerTest.cls
@@ -165,7 +165,7 @@ private class AccessReviewSchedulerTest {
         Test.stopTest();
 
         // Should handle bulk data without governor limit issues
-        System.assert(Limits.getQueries() < 100, 'Should stay under SOQL limit');
-        System.assert(Limits.getDmlStatements() < 150, 'Should stay under DML limit');
+        Assert.isTrue(Limits.getQueries() < 100, 'Should stay under SOQL limit');
+        Assert.isTrue(Limits.getDmlStatements() < 150, 'Should stay under DML limit');
     }
 }

--- a/force-app/main/default/classes/AlertHistoryServiceTest.cls
+++ b/force-app/main/default/classes/AlertHistoryServiceTest.cls
@@ -63,9 +63,9 @@ private class AlertHistoryServiceTest {
         for (AlertHistoryService.AlertRow row : rows) {
             metrics.add(row.metric);
         }
-        System.assert(metrics.contains('CPU'), 'Should include CPU metric');
-        System.assert(metrics.contains('HEAP'), 'Should include HEAP metric');
-        System.assert(metrics.contains('SOQL'), 'Should include SOQL metric');
+        Assert.isTrue(metrics.contains('CPU'), 'Should include CPU metric');
+        Assert.isTrue(metrics.contains('HEAP'), 'Should include HEAP metric');
+        Assert.isTrue(metrics.contains('SOQL'), 'Should include SOQL metric');
     }
 
     @IsTest
@@ -122,7 +122,7 @@ private class AlertHistoryServiceTest {
         // Verify descending order by created date (most recent first)
         Assert.areEqual(3, rows.size(), 'Should return all 3 alerts');
         for (Integer i = 0; i < rows.size() - 1; i++) {
-            System.assert(
+            Assert.isTrue(
                 rows[i].createdDate >= rows[i + 1].createdDate,
                 'Alerts should be ordered by CreatedDate DESC'
             );

--- a/force-app/main/default/classes/AnomalyDetectionServiceTest.cls
+++ b/force-app/main/default/classes/AnomalyDetectionServiceTest.cls
@@ -68,7 +68,7 @@ private class AnomalyDetectionServiceTest {
             AnomalyDetectionService.detectAnomalies(null, 30);
             Assert.fail( 'Should have thrown IllegalArgumentException');
         } catch (IllegalArgumentException e) {
-            System.assert(e.getMessage().contains('Framework is required'),
+            Assert.isTrue(e.getMessage().contains('Framework is required'),
                 'Exception should mention framework');
         }
         Test.stopTest();
@@ -175,8 +175,8 @@ private class AnomalyDetectionServiceTest {
         Datetime afterCreate = System.now();
         Test.stopTest();
 
-        System.assert(anomaly.detectedDate >= beforeCreate, 'DetectedDate should be at or after test start');
-        System.assert(anomaly.detectedDate <= afterCreate, 'DetectedDate should be at or before test end');
+        Assert.isTrue(anomaly.detectedDate >= beforeCreate, 'DetectedDate should be at or after test start');
+        Assert.isTrue(anomaly.detectedDate <= afterCreate, 'DetectedDate should be at or before test end');
     }
 
     @IsTest

--- a/force-app/main/default/classes/BenchmarkingServiceTest.cls
+++ b/force-app/main/default/classes/BenchmarkingServiceTest.cls
@@ -28,7 +28,7 @@ private class BenchmarkingServiceTest {
         Assert.areNotEqual(null, benchmarks, 'Should return benchmarks');
         Assert.areEqual('Healthcare', benchmarks.industry, 'Industry should match');
         Assert.areNotEqual(null, benchmarks.avgComplianceScore, 'Should have average score');
-        System.assert(benchmarks.avgComplianceScore > 0, 'Average score should be positive');
+        Assert.isTrue(benchmarks.avgComplianceScore > 0, 'Average score should be positive');
         Assert.areNotEqual(null, benchmarks.frameworkBenchmarks, 'Should have framework benchmarks');
         Assert.areNotEqual(null, benchmarks.lastUpdated, 'Should have last updated date');
     }
@@ -42,7 +42,7 @@ private class BenchmarkingServiceTest {
         
         Assert.areNotEqual(null, benchmarks, 'Should return benchmarks');
         Assert.areEqual('Financial Services', benchmarks.industry, 'Industry should match');
-        System.assert(benchmarks.avgComplianceScore > 0, 'Average score should be positive');
+        Assert.isTrue(benchmarks.avgComplianceScore > 0, 'Average score should be positive');
     }
     
     @isTest
@@ -65,7 +65,7 @@ private class BenchmarkingServiceTest {
         
         // Should default to Technology
         Assert.areNotEqual(null, benchmarks, 'Should return default benchmarks');
-        System.assert(benchmarks.avgComplianceScore > 0, 'Should have default score');
+        Assert.isTrue(benchmarks.avgComplianceScore > 0, 'Should have default score');
     }
     
     // ═══════════════════════════════════════════════════════════════
@@ -84,7 +84,7 @@ private class BenchmarkingServiceTest {
         Assert.areNotEqual(null, result.orgScore, 'Should have org score');
         Assert.areNotEqual(null, result.industryAvgScore, 'Should have industry average');
         Assert.areNotEqual(null, result.percentile, 'Should have percentile');
-        System.assert(result.percentile >= 0 && result.percentile <= 100, 'Percentile should be 0-100');
+        Assert.isTrue(result.percentile >= 0 && result.percentile <= 100, 'Percentile should be 0-100');
         Assert.areNotEqual(null, result.position, 'Should have position');
         Assert.areNotEqual(null, result.frameworkComparisons, 'Should have framework comparisons');
         Assert.areNotEqual(null, result.recommendations, 'Should have recommendations');
@@ -110,7 +110,7 @@ private class BenchmarkingServiceTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, result.frameworkComparisons, 'Should have framework comparisons');
-        System.assert(result.frameworkComparisons.size() > 0, 'Should have at least one framework comparison');
+        Assert.isTrue(result.frameworkComparisons.size() > 0, 'Should have at least one framework comparison');
         
         for (BenchmarkingService.FrameworkComparison fc : result.frameworkComparisons) {
             Assert.areNotEqual(null, fc.framework, 'Framework should be set');
@@ -136,7 +136,7 @@ private class BenchmarkingServiceTest {
         Assert.areNotEqual(null, assessment.overallLevel, 'Should have overall level');
         Assert.areNotEqual(null, assessment.overallScore, 'Should have overall score');
         Assert.areNotEqual(null, assessment.dimensions, 'Should have dimensions');
-        System.assert(assessment.dimensions.size() > 0, 'Should have at least one dimension');
+        Assert.isTrue(assessment.dimensions.size() > 0, 'Should have at least one dimension');
         Assert.areNotEqual(null, assessment.improvementRoadmap, 'Should have roadmap');
         Assert.areNotEqual(null, assessment.assessedAt, 'Should have assessment timestamp');
     }
@@ -148,23 +148,23 @@ private class BenchmarkingServiceTest {
             BenchmarkingService.assessMaturity();
         Test.stopTest();
         
-        System.assert(assessment.dimensions.size() >= 4, 'Should have at least 4 dimensions');
+        Assert.isTrue(assessment.dimensions.size() >= 4, 'Should have at least 4 dimensions');
         
         Set<String> dimensionNames = new Set<String>();
         for (BenchmarkingService.MaturityDimension dim : assessment.dimensions) {
             Assert.areNotEqual(null, dim.name, 'Dimension should have name');
             Assert.areNotEqual(null, dim.description, 'Dimension should have description');
             Assert.areNotEqual(null, dim.score, 'Dimension should have score');
-            System.assert(dim.score >= 0 && dim.score <= 100, 'Score should be 0-100');
+            Assert.isTrue(dim.score >= 0 && dim.score <= 100, 'Score should be 0-100');
             Assert.areNotEqual(null, dim.level, 'Dimension should have maturity level');
             dimensionNames.add(dim.name);
         }
         
         // Verify expected dimensions
-        System.assert(dimensionNames.contains('Process'), 'Should have Process dimension');
-        System.assert(dimensionNames.contains('Technology'), 'Should have Technology dimension');
-        System.assert(dimensionNames.contains('People'), 'Should have People dimension');
-        System.assert(dimensionNames.contains('Governance'), 'Should have Governance dimension');
+        Assert.isTrue(dimensionNames.contains('Process'), 'Should have Process dimension');
+        Assert.isTrue(dimensionNames.contains('Technology'), 'Should have Technology dimension');
+        Assert.isTrue(dimensionNames.contains('People'), 'Should have People dimension');
+        Assert.isTrue(dimensionNames.contains('Governance'), 'Should have Governance dimension');
     }
     
     @isTest
@@ -182,7 +182,7 @@ private class BenchmarkingServiceTest {
             Assert.areNotEqual(null, item.targetLevel, 'Roadmap item should have target level');
             Assert.areNotEqual(null, item.priority, 'Roadmap item should have priority');
             Assert.areNotEqual(null, item.actions, 'Roadmap item should have actions');
-            System.assert(item.actions.size() > 0, 'Roadmap item should have at least one action');
+            Assert.isTrue(item.actions.size() > 0, 'Roadmap item should have at least one action');
         }
     }
     
@@ -197,14 +197,14 @@ private class BenchmarkingServiceTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, industries, 'Should return industries list');
-        System.assert(industries.size() > 0, 'Should have at least one industry');
+        Assert.isTrue(industries.size() > 0, 'Should have at least one industry');
         
         // Verify expected industries
-        System.assert(industries.contains('Healthcare'), 'Should include Healthcare');
-        System.assert(industries.contains('Financial Services'), 'Should include Financial Services');
-        System.assert(industries.contains('Technology'), 'Should include Technology');
-        System.assert(industries.contains('Retail'), 'Should include Retail');
-        System.assert(industries.contains('Government'), 'Should include Government');
+        Assert.isTrue(industries.contains('Healthcare'), 'Should include Healthcare');
+        Assert.isTrue(industries.contains('Financial Services'), 'Should include Financial Services');
+        Assert.isTrue(industries.contains('Technology'), 'Should include Technology');
+        Assert.isTrue(industries.contains('Retail'), 'Should include Retail');
+        Assert.isTrue(industries.contains('Government'), 'Should include Government');
     }
     
     // ═══════════════════════════════════════════════════════════════
@@ -294,7 +294,7 @@ private class BenchmarkingServiceTest {
         // Recommendations should be actionable
         for (String recommendation : result.recommendations) {
             Assert.areNotEqual(null, recommendation, 'Recommendation should not be null');
-            System.assert(recommendation.length() > 0, 'Recommendation should have content');
+            Assert.isTrue(recommendation.length() > 0, 'Recommendation should have content');
         }
     }
 }

--- a/force-app/main/default/classes/BlockchainVerificationTest.cls
+++ b/force-app/main/default/classes/BlockchainVerificationTest.cls
@@ -127,7 +127,7 @@ private class BlockchainVerificationTest {
         List<BlockchainVerification.VerificationRecord> history = BlockchainVerification.getVerificationHistory(pkg.Id);
         Test.stopTest();
 
-        System.assert(history.size() > 0, 'Should have verification records');
+        Assert.isTrue(history.size() > 0, 'Should have verification records');
     }
 
     @isTest
@@ -141,8 +141,8 @@ private class BlockchainVerificationTest {
         String certificate = BlockchainVerification.generateCertificate(cv.Id);
         Test.stopTest();
 
-        System.assert(certificate.contains('CERTIFICATE OF AUTHENTICITY'), 'Certificate should have proper header');
-        System.assert(certificate.contains('AUTHENTIC'), 'Certificate should confirm authenticity');
+        Assert.isTrue(certificate.contains('CERTIFICATE OF AUTHENTICITY'), 'Certificate should have proper header');
+        Assert.isTrue(certificate.contains('AUTHENTIC'), 'Certificate should confirm authenticity');
     }
 
     @isTest
@@ -161,7 +161,7 @@ private class BlockchainVerificationTest {
             BlockchainVerification.generateCertificate(cv.Id);
             Assert.fail( 'Should throw exception');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('not verified'), 'Error should indicate not verified');
+            Assert.isTrue(e.getMessage().contains('not verified'), 'Error should indicate not verified');
         }
         Test.stopTest();
     }

--- a/force-app/main/default/classes/BreachDeadlineMonitorTest.cls
+++ b/force-app/main/default/classes/BreachDeadlineMonitorTest.cls
@@ -117,7 +117,7 @@ private class BreachDeadlineMonitorTest {
             AND CreatedDate = TODAY
         ];
 
-        System.assert(gaps.size() > 0, 'Should create compliance gaps for breaches');
+        Assert.isTrue(gaps.size() > 0, 'Should create compliance gaps for breaches');
     }
 
     @IsTest
@@ -192,10 +192,10 @@ private class BreachDeadlineMonitorTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, summary, 'Should return deadline summary');
-        System.assert(summary.overdueCount >= 0, 'Overdue count should be valid');
-        System.assert(summary.criticalCount >= 0, 'Critical count should be valid');
-        System.assert(summary.upcomingCount >= 0, 'Upcoming count should be valid');
-        System.assert(summary.hhsRequiredCount >= 0, 'HHS required count should be valid');
+        Assert.isTrue(summary.overdueCount >= 0, 'Overdue count should be valid');
+        Assert.isTrue(summary.criticalCount >= 0, 'Critical count should be valid');
+        Assert.isTrue(summary.upcomingCount >= 0, 'Upcoming count should be valid');
+        Assert.isTrue(summary.hhsRequiredCount >= 0, 'HHS required count should be valid');
     }
 
     @IsTest
@@ -260,7 +260,7 @@ private class BreachDeadlineMonitorTest {
         Test.stopTest();
 
         // Should handle bulk data without governor limit issues
-        System.assert(Limits.getQueries() < 100, 'Should stay under SOQL limit');
-        System.assert(Limits.getDmlStatements() < 150, 'Should stay under DML limit');
+        Assert.isTrue(Limits.getQueries() < 100, 'Should stay under SOQL limit');
+        Assert.isTrue(Limits.getDmlStatements() < 150, 'Should stay under DML limit');
     }
 }

--- a/force-app/main/default/classes/CCPAConsumerRightsServiceTest.cls
+++ b/force-app/main/default/classes/CCPAConsumerRightsServiceTest.cls
@@ -67,7 +67,7 @@ private class CCPAConsumerRightsServiceTest {
         }
         Test.stopTest();
         
-        System.assert(results.size() > 0, 'Should process bulk requests');
+        Assert.isTrue(results.size() > 0, 'Should process bulk requests');
     }
     
     @IsTest
@@ -175,7 +175,7 @@ private class CCPAConsumerRightsServiceTest {
             service.handleKnowRequest(null, null);
             Assert.fail( 'Should throw exception for null parameters');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should validate required parameters');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should validate required parameters');
         }
         Test.stopTest();
     }

--- a/force-app/main/default/classes/CCPADataInventoryServiceTest.cls
+++ b/force-app/main/default/classes/CCPADataInventoryServiceTest.cls
@@ -33,7 +33,7 @@ private class CCPADataInventoryServiceTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, result, 'Categorization should not be null');
-        System.assert(result.containsKey('categories'), 'Should include categories');
+        Assert.isTrue(result.containsKey('categories'), 'Should include categories');
     }
     
     @IsTest
@@ -60,8 +60,8 @@ private class CCPADataInventoryServiceTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, result, 'Sharing data should not be null');
-        System.assert(result.containsKey('totalRecipients'), 'Should include recipient count');
-        System.assert(result.containsKey('recipientsWithDPA'), 'Should include DPA count');
+        Assert.isTrue(result.containsKey('totalRecipients'), 'Should include recipient count');
+        Assert.isTrue(result.containsKey('recipientsWithDPA'), 'Should include DPA count');
     }
     
     @IsTest
@@ -76,7 +76,7 @@ private class CCPADataInventoryServiceTest {
             Assert.areNotEqual(null, evidence, 'Evidence should not be null');
         } catch (Exception e) {
             // May fail if control doesn't exist
-            System.assert(e.getMessage().contains('Control not found') || e.getMessage().contains('required'), 
+            Assert.isTrue(e.getMessage().contains('Control not found') || e.getMessage().contains('required'), 
                 'Should handle missing control gracefully');
         }
         Test.stopTest();
@@ -132,7 +132,7 @@ private class CCPADataInventoryServiceTest {
             service.generateEvidenceReport('INVALID', parameters);
             Assert.fail( 'Should throw exception for invalid report type');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Unsupported'), 'Should throw unsupported error');
+            Assert.isTrue(e.getMessage().contains('Unsupported'), 'Should throw unsupported error');
         }
         Test.stopTest();
     }

--- a/force-app/main/default/classes/CCPAOptOutServiceTest.cls
+++ b/force-app/main/default/classes/CCPAOptOutServiceTest.cls
@@ -52,7 +52,7 @@ private class CCPAOptOutServiceTest {
         }
         Test.stopTest();
         
-        System.assert(results.size() > 0, 'Should process bulk opt-outs');
+        Assert.isTrue(results.size() > 0, 'Should process bulk opt-outs');
     }
     
     @IsTest
@@ -127,7 +127,7 @@ private class CCPAOptOutServiceTest {
         Test.stopTest();
         
         Assert.areEqual(true, result.get('success'), 'Vendor sync should succeed');
-        System.assert(result.containsKey('vendorsSynced'), 'Should include vendor count');
+        Assert.isTrue(result.containsKey('vendorsSynced'), 'Should include vendor count');
     }
     
     @IsTest
@@ -138,7 +138,7 @@ private class CCPAOptOutServiceTest {
             service.processOptOut(null);
             Assert.fail( 'Should throw exception for null contact');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should validate required parameters');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should validate required parameters');
         }
         Test.stopTest();
     }
@@ -151,7 +151,7 @@ private class CCPAOptOutServiceTest {
             service.honorGPC(null, true);
             Assert.fail( 'Should throw exception for null contact');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should validate required parameters');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should validate required parameters');
         }
         Test.stopTest();
     }

--- a/force-app/main/default/classes/ComplianceFrameworkServiceTest.cls
+++ b/force-app/main/default/classes/ComplianceFrameworkServiceTest.cls
@@ -74,6 +74,6 @@ private class ComplianceFrameworkServiceTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, frameworks, 'Frameworks list should not be null');
-        System.assert(!frameworks.isEmpty(), 'Should have at least one framework');
+        Assert.isTrue(!frameworks.isEmpty(), 'Should have at least one framework');
     }
 }

--- a/force-app/main/default/classes/ComplianceGraphServiceTest.cls
+++ b/force-app/main/default/classes/ComplianceGraphServiceTest.cls
@@ -83,8 +83,8 @@ private class ComplianceGraphServiceTest {
         Assert.areNotEqual(null, graph, 'Graph should not be null');
         Assert.areNotEqual(null, graph.nodes, 'Nodes should not be null');
         Assert.areNotEqual(null, graph.edges, 'Edges should not be null');
-        System.assert(graph.nodes.size() > 0, 'Should have nodes');
-        System.assert(graph.edges.size() > 0, 'Should have edges');
+        Assert.isTrue(graph.nodes.size() > 0, 'Should have nodes');
+        Assert.isTrue(graph.edges.size() > 0, 'Should have edges');
 
         // Verify node types
         Set<String> nodeTypes = new Set<String>();
@@ -93,8 +93,8 @@ private class ComplianceGraphServiceTest {
             Assert.areNotEqual(null, node.id, 'Node ID should be set');
             Assert.areNotEqual(null, node.label, 'Node label should be set');
         }
-        System.assert(nodeTypes.contains('framework'), 'Should have framework nodes');
-        System.assert(nodeTypes.contains('gap'), 'Should have gap nodes');
+        Assert.isTrue(nodeTypes.contains('framework'), 'Should have framework nodes');
+        Assert.isTrue(nodeTypes.contains('gap'), 'Should have gap nodes');
     }
 
     @isTest
@@ -104,7 +104,7 @@ private class ComplianceGraphServiceTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, graph, 'Graph should not be null');
-        System.assert(graph.nodes.size() > 0, 'Should have nodes');
+        Assert.isTrue(graph.nodes.size() > 0, 'Should have nodes');
 
         // Verify all gaps are SOX
         for (ComplianceGraphService.GraphNode node : graph.nodes) {
@@ -123,9 +123,9 @@ private class ComplianceGraphServiceTest {
         Assert.areNotEqual(null, analysis, 'Analysis should not be null');
         Assert.areEqual('PERMISSION_SET', analysis.entityType, 'Entity type should match');
         Assert.areEqual('0PS000000000001', analysis.entityId, 'Entity ID should match');
-        System.assert(analysis.totalGaps >= 2, 'Should have at least 2 gaps affecting this entity');
-        System.assert(analysis.affectedFrameworks.size() >= 2, 'Should affect multiple frameworks');
-        System.assert(analysis.riskScore > 0, 'Risk score should be positive');
+        Assert.isTrue(analysis.totalGaps >= 2, 'Should have at least 2 gaps affecting this entity');
+        Assert.isTrue(analysis.affectedFrameworks.size() >= 2, 'Should affect multiple frameworks');
+        Assert.isTrue(analysis.riskScore > 0, 'Risk score should be positive');
     }
 
     @isTest
@@ -294,10 +294,10 @@ private class ComplianceGraphServiceTest {
         for (ComplianceGraphService.GraphNode node : graph.nodes) {
             if (node.nodeType == 'entity') {
                 hasEntityNode = true;
-                System.assert(node.id.startsWith('entity-'), 'Entity node ID should start with entity-');
+                Assert.isTrue(node.id.startsWith('entity-'), 'Entity node ID should start with entity-');
             }
         }
-        System.assert(hasEntityNode, 'Should have entity nodes for gaps with entity info');
+        Assert.isTrue(hasEntityNode, 'Should have entity nodes for gaps with entity info');
     }
 
     @isTest
@@ -313,7 +313,7 @@ private class ComplianceGraphServiceTest {
             Assert.areNotEqual(null, edge.target, 'Edge target should be set');
         }
 
-        System.assert(edgeTypes.contains('HAS_GAP'), 'Should have HAS_GAP edges');
-        System.assert(edgeTypes.contains('FRAMEWORK_GAP'), 'Should have FRAMEWORK_GAP edges');
+        Assert.isTrue(edgeTypes.contains('HAS_GAP'), 'Should have HAS_GAP edges');
+        Assert.isTrue(edgeTypes.contains('FRAMEWORK_GAP'), 'Should have FRAMEWORK_GAP edges');
     }
 }

--- a/force-app/main/default/classes/ComplianceReportGeneratorTest.cls
+++ b/force-app/main/default/classes/ComplianceReportGeneratorTest.cls
@@ -161,7 +161,7 @@ private class ComplianceReportGeneratorTest {
 
         Assert.areNotEqual(null, data.scoreTrend, 'Score trend should not be null');
         // Trend points should exist if Compliance_Score__c records exist
-        System.assert(data.scoreTrend.size() >= 0, 'Score trend should be populated');
+        Assert.isTrue(data.scoreTrend.size() >= 0, 'Score trend should be populated');
     }
 
     /**
@@ -176,8 +176,8 @@ private class ComplianceReportGeneratorTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, summary, 'Summary should not be null');
-        System.assert(summary.contains('Compliance Score'), 'Summary should contain compliance score');
-        System.assert(summary.contains('Critical'), 'Summary should mention critical gaps');
+        Assert.isTrue(summary.contains('Compliance Score'), 'Summary should contain compliance score');
+        Assert.isTrue(summary.contains('Critical'), 'Summary should mention critical gaps');
     }
 
     /**
@@ -189,7 +189,7 @@ private class ComplianceReportGeneratorTest {
         String summary = ComplianceReportGenerator.generateExecutiveSummary(null);
         Test.stopTest();
 
-        System.assert(summary.contains('Unable to generate'), 'Should return error message for null data');
+        Assert.isTrue(summary.contains('Unable to generate'), 'Should return error message for null data');
     }
 
     /**
@@ -204,7 +204,7 @@ private class ComplianceReportGeneratorTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, recommendations, 'Recommendations should not be null');
-        System.assert(!recommendations.isEmpty(), 'Should have at least one recommendation');
+        Assert.isTrue(!recommendations.isEmpty(), 'Should have at least one recommendation');
     }
 
     /**
@@ -225,7 +225,7 @@ private class ComplianceReportGeneratorTest {
                 break;
             }
         }
-        System.assert(hasCriticalRecommendation, 'Should have recommendation about critical gaps');
+        Assert.isTrue(hasCriticalRecommendation, 'Should have recommendation about critical gaps');
     }
 
     /**
@@ -237,8 +237,8 @@ private class ComplianceReportGeneratorTest {
         List<String> recommendations = ComplianceReportGenerator.generateRecommendations(null);
         Test.stopTest();
 
-        System.assert(!recommendations.isEmpty(), 'Should return at least one message');
-        System.assert(recommendations[0].contains('Unable'), 'Should indicate unable to generate');
+        Assert.isTrue(!recommendations.isEmpty(), 'Should return at least one message');
+        Assert.isTrue(recommendations[0].contains('Unable'), 'Should indicate unable to generate');
     }
 
     /**
@@ -303,7 +303,7 @@ private class ComplianceReportGeneratorTest {
         Test.stopTest();
 
         // Should handle bulk data within limits (200 limit in query)
-        System.assert(data.gaps.size() <= 200, 'Should respect query limit');
+        Assert.isTrue(data.gaps.size() <= 200, 'Should respect query limit');
         Assert.areNotEqual(null, data.scoreResult, 'Should still calculate score');
     }
 

--- a/force-app/main/default/classes/ComplianceReportSchedulerTest.cls
+++ b/force-app/main/default/classes/ComplianceReportSchedulerTest.cls
@@ -44,7 +44,7 @@ private class ComplianceReportSchedulerTest {
             WHERE Id = :jobId
         ];
         Assert.areEqual(1, jobs.size(), 'Should have one scheduled job');
-        System.assert(jobs[0].CronJobDetail.Name.contains('WEEKLY'), 'Job name should contain WEEKLY');
+        Assert.isTrue(jobs[0].CronJobDetail.Name.contains('WEEKLY'), 'Job name should contain WEEKLY');
     }
 
     /**
@@ -61,7 +61,7 @@ private class ComplianceReportSchedulerTest {
         Assert.areNotEqual(null, jobId, 'Job ID should not be null');
 
         CronTrigger job = [SELECT CronExpression FROM CronTrigger WHERE Id = :jobId];
-        System.assert(job.CronExpression.contains('8 * * ?'), 'Should run at 8 AM daily');
+        Assert.isTrue(job.CronExpression.contains('8 * * ?'), 'Should run at 8 AM daily');
     }
 
     /**
@@ -78,7 +78,7 @@ private class ComplianceReportSchedulerTest {
         Assert.areNotEqual(null, jobId, 'Job ID should not be null');
 
         CronTrigger job = [SELECT CronExpression FROM CronTrigger WHERE Id = :jobId];
-        System.assert(job.CronExpression.contains('8 1 * ?'), 'Should run on 1st of month');
+        Assert.isTrue(job.CronExpression.contains('8 1 * ?'), 'Should run on 1st of month');
     }
 
     /**
@@ -94,7 +94,7 @@ private class ComplianceReportSchedulerTest {
         List<ComplianceReportScheduler.ScheduledReport> reports = ComplianceReportScheduler.getScheduledReports();
         Test.stopTest();
 
-        System.assert(reports.size() >= 1, 'Should have at least one scheduled report');
+        Assert.isTrue(reports.size() >= 1, 'Should have at least one scheduled report');
 
         ComplianceReportScheduler.ScheduledReport report = reports[0];
         Assert.areNotEqual(null, report.jobId, 'Job ID should not be null');
@@ -194,7 +194,7 @@ private class ComplianceReportSchedulerTest {
             ComplianceReportScheduler.scheduleReport('INVALID', recipients, 'ALL');
             Assert.fail( 'Should throw exception for invalid frequency');
         } catch (IllegalArgumentException e) {
-            System.assert(e.getMessage().contains('Invalid frequency'), 'Should mention invalid frequency');
+            Assert.isTrue(e.getMessage().contains('Invalid frequency'), 'Should mention invalid frequency');
         }
         Test.stopTest();
     }
@@ -209,7 +209,7 @@ private class ComplianceReportSchedulerTest {
             ComplianceReportScheduler.scheduleReport('WEEKLY', new List<String>(), 'ALL');
             Assert.fail( 'Should throw exception for no recipients');
         } catch (IllegalArgumentException e) {
-            System.assert(e.getMessage().contains('recipient'), 'Should mention recipients');
+            Assert.isTrue(e.getMessage().contains('recipient'), 'Should mention recipients');
         }
         Test.stopTest();
     }
@@ -226,7 +226,7 @@ private class ComplianceReportSchedulerTest {
             ComplianceReportScheduler.scheduleReport('WEEKLY', badEmails, 'ALL');
             Assert.fail( 'Should throw exception for invalid emails');
         } catch (IllegalArgumentException e) {
-            System.assert(e.getMessage().contains('recipient'), 'Should mention recipients');
+            Assert.isTrue(e.getMessage().contains('recipient'), 'Should mention recipients');
         }
         Test.stopTest();
     }
@@ -243,7 +243,7 @@ private class ComplianceReportSchedulerTest {
             ComplianceReportScheduler.scheduleReport('WEEKLY', recipients, 'INVALID_FRAMEWORK');
             Assert.fail( 'Should throw exception for invalid framework');
         } catch (IllegalArgumentException e) {
-            System.assert(e.getMessage().contains('Invalid framework'), 'Should mention invalid framework');
+            Assert.isTrue(e.getMessage().contains('Invalid framework'), 'Should mention invalid framework');
         }
         Test.stopTest();
     }
@@ -258,7 +258,7 @@ private class ComplianceReportSchedulerTest {
             ComplianceReportScheduler.cancelScheduledReport(null);
             Assert.fail( 'Should throw exception for null job ID');
         } catch (IllegalArgumentException e) {
-            System.assert(e.getMessage().contains('Job ID'), 'Should mention job ID');
+            Assert.isTrue(e.getMessage().contains('Job ID'), 'Should mention job ID');
         }
         Test.stopTest();
     }

--- a/force-app/main/default/classes/ComplianceScoreCardControllerTest.cls
+++ b/force-app/main/default/classes/ComplianceScoreCardControllerTest.cls
@@ -80,9 +80,9 @@ private class ComplianceScoreCardControllerTest {
         
         Assert.areNotEqual(null, details, 'Details should not be null');
         Assert.areEqual('SOC2', details.framework, 'Framework should match');
-        System.assert(details.mappingCount >= 0, 'Mapping count should be non-negative');
-        System.assert(details.evidenceCount >= 0, 'Evidence count should be non-negative');
-        System.assert(details.requirementCount > 0, 'Should have requirements');
+        Assert.isTrue(details.mappingCount >= 0, 'Mapping count should be non-negative');
+        Assert.isTrue(details.evidenceCount >= 0, 'Evidence count should be non-negative');
+        Assert.isTrue(details.requirementCount > 0, 'Should have requirements');
     }
     
     @IsTest
@@ -92,7 +92,7 @@ private class ComplianceScoreCardControllerTest {
             ComplianceScoreCardController.getFrameworkDetails('');
             Assert.fail( 'Should have thrown AuraHandledException');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('blank'), 'Should mention blank framework');
+            Assert.isTrue(e.getMessage().contains('blank'), 'Should mention blank framework');
         }
         Test.stopTest();
     }
@@ -104,7 +104,7 @@ private class ComplianceScoreCardControllerTest {
             ComplianceScoreCardController.getFrameworkDetails('INVALID');
             Assert.fail( 'Should have thrown AuraHandledException');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Unsupported'), 'Should mention unsupported framework');
+            Assert.isTrue(e.getMessage().contains('Unsupported'), 'Should mention unsupported framework');
         }
         Test.stopTest();
     }

--- a/force-app/main/default/classes/ComplianceScoreSnapshotSchedulerTest.cls
+++ b/force-app/main/default/classes/ComplianceScoreSnapshotSchedulerTest.cls
@@ -70,7 +70,7 @@ private class ComplianceScoreSnapshotSchedulerTest {
             WHERE CreatedDate = TODAY
         ];
 
-        System.assert(newSnapshots.size() > 0, 'Should create compliance score snapshots');
+        Assert.isTrue(newSnapshots.size() > 0, 'Should create compliance score snapshots');
     }
 
     @IsTest
@@ -235,7 +235,7 @@ private class ComplianceScoreSnapshotSchedulerTest {
         Test.stopTest();
 
         // Should handle bulk data without governor limit issues
-        System.assert(Limits.getQueries() < 100, 'Should stay under SOQL limit');
-        System.assert(Limits.getDmlStatements() < 150, 'Should stay under DML limit');
+        Assert.isTrue(Limits.getQueries() < 100, 'Should stay under SOQL limit');
+        Assert.isTrue(Limits.getDmlStatements() < 150, 'Should stay under DML limit');
     }
 }

--- a/force-app/main/default/classes/ComplianceServiceBaseTest.cls
+++ b/force-app/main/default/classes/ComplianceServiceBaseTest.cls
@@ -29,8 +29,8 @@ private class ComplianceServiceBaseTest {
         Test.stopTest();
 
         // Base 5.0 + 3.0 (modifyAll) = 8.0, then * multiplier (0.95) = 7.6
-        System.assert(score > 5, 'Score should be elevated for ModifyAll permission');
-        System.assert(score <= 10, 'Score should not exceed 10');
+        Assert.isTrue(score > 5, 'Score should be elevated for ModifyAll permission');
+        Assert.isTrue(score <= 10, 'Score should not exceed 10');
     }
 
     @IsTest
@@ -49,7 +49,7 @@ private class ComplianceServiceBaseTest {
         Test.stopTest();
 
         // Base 5.0 + 2.0 (viewAll) = 7.0, then * multiplier
-        System.assert(score > 5, 'Score should be elevated for ViewAll permission');
+        Assert.isTrue(score > 5, 'Score should be elevated for ViewAll permission');
     }
 
     @IsTest
@@ -68,7 +68,7 @@ private class ComplianceServiceBaseTest {
         Test.stopTest();
 
         // Base 5.0 + 3.0 + 2.0 = 10.0 (capped), then * multiplier
-        System.assert(score > 7, 'Score should be high for both permissions');
+        Assert.isTrue(score > 7, 'Score should be high for both permissions');
     }
 
     @IsTest
@@ -86,7 +86,7 @@ private class ComplianceServiceBaseTest {
         Test.stopTest();
 
         // Base 5.0 + 2.0 (Edit) = 7.0, then * multiplier
-        System.assert(score > 5, 'Score should be elevated for Edit access');
+        Assert.isTrue(score > 5, 'Score should be elevated for Edit access');
     }
 
     @IsTest
@@ -104,7 +104,7 @@ private class ComplianceServiceBaseTest {
         Test.stopTest();
 
         // Base 5.0 + 3.0 (All) = 8.0, then * multiplier
-        System.assert(score > 6, 'Score should be elevated for All access');
+        Assert.isTrue(score > 6, 'Score should be elevated for All access');
     }
 
     @IsTest
@@ -123,7 +123,7 @@ private class ComplianceServiceBaseTest {
         Test.stopTest();
 
         // Base 5.0 + 3.0 (sensitive+unencrypted) = 8.0, then * multiplier
-        System.assert(score > 6, 'Score should be elevated for sensitive unencrypted field');
+        Assert.isTrue(score > 6, 'Score should be elevated for sensitive unencrypted field');
     }
 
     @IsTest
@@ -142,7 +142,7 @@ private class ComplianceServiceBaseTest {
         Test.stopTest();
 
         // Base 5.0 (no penalty for encrypted), then * multiplier
-        System.assert(score <= 5, 'Score should be base level for encrypted sensitive field');
+        Assert.isTrue(score <= 5, 'Score should be base level for encrypted sensitive field');
     }
 
     @IsTest
@@ -158,8 +158,8 @@ private class ComplianceServiceBaseTest {
         Test.stopTest();
 
         // Base 5.0 * multiplier
-        System.assert(score >= 0, 'Score should be non-negative');
-        System.assert(score <= 10, 'Score should not exceed 10');
+        Assert.isTrue(score >= 0, 'Score should be non-negative');
+        Assert.isTrue(score <= 10, 'Score should not exceed 10');
     }
 
     // =============================================
@@ -181,7 +181,7 @@ private class ComplianceServiceBaseTest {
         );
 
         // Score >= 9 * multiplier means critical range
-        System.assert(highScore > 7, 'High-risk entity should produce high score');
+        Assert.isTrue(highScore > 7, 'High-risk entity should produce high score');
     }
 
     // =============================================

--- a/force-app/main/default/classes/ComplianceServiceFactoryTest.cls
+++ b/force-app/main/default/classes/ComplianceServiceFactoryTest.cls
@@ -18,7 +18,7 @@ private class ComplianceServiceFactoryTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, service, 'Should return HIPAA service');
-        System.assert(service instanceof ElaroHIPAAComplianceService,
+        Assert.isTrue(service instanceof ElaroHIPAAComplianceService,
             'Should return correct service type');
     }
 
@@ -31,7 +31,7 @@ private class ComplianceServiceFactoryTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, service, 'Should return SOC2 service');
-        System.assert(service instanceof ElaroSOC2ComplianceService,
+        Assert.isTrue(service instanceof ElaroSOC2ComplianceService,
             'Should return correct service type');
     }
 
@@ -44,7 +44,7 @@ private class ComplianceServiceFactoryTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, service, 'Should return GDPR service');
-        System.assert(service instanceof ElaroGDPRComplianceService,
+        Assert.isTrue(service instanceof ElaroGDPRComplianceService,
             'Should return correct service type');
     }
 
@@ -57,7 +57,7 @@ private class ComplianceServiceFactoryTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, service, 'Should return CCPA service');
-        System.assert(service instanceof ElaroCCPAComplianceService,
+        Assert.isTrue(service instanceof ElaroCCPAComplianceService,
             'Should return correct service type');
     }
 
@@ -70,7 +70,7 @@ private class ComplianceServiceFactoryTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, service, 'Should return PCI-DSS service');
-        System.assert(service instanceof ElaroPCIDSSComplianceService,
+        Assert.isTrue(service instanceof ElaroPCIDSSComplianceService,
             'Should return correct service type');
     }
 
@@ -96,7 +96,7 @@ private class ComplianceServiceFactoryTest {
             ComplianceServiceFactory.getService('');
             Assert.fail( 'Should throw exception for blank framework');
         } catch (ComplianceServiceFactory.ComplianceServiceException e) {
-            System.assert(e.getMessage().contains('blank'),
+            Assert.isTrue(e.getMessage().contains('blank'),
                 'Should mention blank in error message');
         }
 
@@ -192,11 +192,11 @@ private class ComplianceServiceFactoryTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, frameworks, 'Should return supported frameworks');
-        System.assert(frameworks.contains('HIPAA'), 'Should include HIPAA');
-        System.assert(frameworks.contains('SOC2'), 'Should include SOC2');
-        System.assert(frameworks.contains('GDPR'), 'Should include GDPR');
-        System.assert(frameworks.contains('CCPA'), 'Should include CCPA');
-        System.assert(frameworks.contains('PCI_DSS'), 'Should include PCI_DSS');
+        Assert.isTrue(frameworks.contains('HIPAA'), 'Should include HIPAA');
+        Assert.isTrue(frameworks.contains('SOC2'), 'Should include SOC2');
+        Assert.isTrue(frameworks.contains('GDPR'), 'Should include GDPR');
+        Assert.isTrue(frameworks.contains('CCPA'), 'Should include CCPA');
+        Assert.isTrue(frameworks.contains('PCI_DSS'), 'Should include PCI_DSS');
     }
 
     @IsTest

--- a/force-app/main/default/classes/ConsentExpirationBatchTest.cls
+++ b/force-app/main/default/classes/ConsentExpirationBatchTest.cls
@@ -38,7 +38,7 @@ private class ConsentExpirationBatchTest {
     static void testBatchExecutionWithDefaultWarningDays() {
         // Arrange
         Integer consentCount = [SELECT COUNT() FROM Consent__c WHERE Consent_Given__c = true];
-        System.assert(consentCount > 0, 'Test data should exist');
+        Assert.isTrue(consentCount > 0, 'Test data should exist');
 
         // Act
         Test.startTest();

--- a/force-app/main/default/classes/ConsentExpirationSchedulerTest.cls
+++ b/force-app/main/default/classes/ConsentExpirationSchedulerTest.cls
@@ -80,7 +80,7 @@ private class ConsentExpirationSchedulerTest {
             WHERE JobType = 'BatchApex'
             AND ApexClass.Name = 'ConsentExpirationBatch'
         ];
-        System.assert(jobs.size() > 0, 'Batch job should have been queued');
+        Assert.isTrue(jobs.size() > 0, 'Batch job should have been queued');
     }
 
     @isTest

--- a/force-app/main/default/classes/DataResidencyServiceTest.cls
+++ b/force-app/main/default/classes/DataResidencyServiceTest.cls
@@ -27,7 +27,7 @@ private class DataResidencyServiceTest {
         Assert.areNotEqual(null, config, 'Config should not be null');
         Assert.areNotEqual(null, config.orgInstance, 'Org instance should be set');
         Assert.areNotEqual(null, config.primaryRegion, 'Primary region should be set');
-        System.assert(config.allowedRegions.size() > 0, 'Allowed regions should be populated');
+        Assert.isTrue(config.allowedRegions.size() > 0, 'Allowed regions should be populated');
     }
 
     @isTest
@@ -66,7 +66,7 @@ private class DataResidencyServiceTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, summary, 'Summary should not be null');
-        System.assert(summary.totalRecords >= 0, 'Total records should be non-negative');
+        Assert.isTrue(summary.totalRecords >= 0, 'Total records should be non-negative');
         Assert.areNotEqual(null, summary.primaryRegion, 'Primary region should be set');
     }
 
@@ -78,7 +78,7 @@ private class DataResidencyServiceTest {
 
         Assert.areNotEqual(null, status, 'Status should not be null');
         Assert.areNotEqual(null, status.transferMechanism, 'Transfer mechanism should be set');
-        System.assert(status.euDataSubjectsCount >= 0, 'EU data subjects count should be non-negative');
+        Assert.isTrue(status.euDataSubjectsCount >= 0, 'EU data subjects count should be non-negative');
     }
 
     @isTest

--- a/force-app/main/default/classes/DeploymentMetricsTest.cls
+++ b/force-app/main/default/classes/DeploymentMetricsTest.cls
@@ -33,7 +33,7 @@ private class DeploymentMetricsTest {
 
         Assert.areEqual(3, rows.size(), 'Should return 3 records');
         // Verify ordering (most recent first)
-        System.assert(rows[0].startedOn >= rows[1].startedOn, 'Should be ordered by startedOn DESC');
+        Assert.isTrue(rows[0].startedOn >= rows[1].startedOn, 'Should be ordered by startedOn DESC');
     }
 
     @IsTest

--- a/force-app/main/default/classes/ElaroAISettingsControllerTest.cls
+++ b/force-app/main/default/classes/ElaroAISettingsControllerTest.cls
@@ -99,7 +99,7 @@ private class ElaroAISettingsControllerTest {
             ElaroAISettingsController.saveSettings(settings);
             // If we reach here with valid data, that's acceptable
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Error saving settings'),
+            Assert.isTrue(e.getMessage().contains('Error saving settings'),
                 'Should throw AuraHandledException with appropriate message');
         }
         Test.stopTest();

--- a/force-app/main/default/classes/ElaroBatchEventLoaderTest.cls
+++ b/force-app/main/default/classes/ElaroBatchEventLoaderTest.cls
@@ -51,8 +51,8 @@ private class ElaroBatchEventLoaderTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, batchId, 'Batch ID should not be null');
-        System.assert(Limits.getQueries() < 100, 'Should stay under SOQL limit');
-        System.assert(Limits.getDmlStatements() < 150, 'Should stay under DML limit');
+        Assert.isTrue(Limits.getQueries() < 100, 'Should stay under SOQL limit');
+        Assert.isTrue(Limits.getDmlStatements() < 150, 'Should stay under DML limit');
     }
 
     @isTest

--- a/force-app/main/default/classes/ElaroBulkOperationTest.cls
+++ b/force-app/main/default/classes/ElaroBulkOperationTest.cls
@@ -181,8 +181,8 @@ private class ElaroBulkOperationTest {
         Test.stopTest();
         
         Assert.areEqual(200, queriedAccounts.size(), 'Should query all 200 accounts');
-        System.assert(endQueries - startQueries < 10, 'Should use reasonable number of queries');
-        System.assert(endDml - startDml == 1, 'Should use single DML statement for bulk insert');
+        Assert.isTrue(endQueries - startQueries < 10, 'Should use reasonable number of queries');
+        Assert.isTrue(endDml - startDml == 1, 'Should use single DML statement for bulk insert');
     }
     
     /**

--- a/force-app/main/default/classes/ElaroCCPAComplianceServiceTest.cls
+++ b/force-app/main/default/classes/ElaroCCPAComplianceServiceTest.cls
@@ -18,7 +18,7 @@ private class ElaroCCPAComplianceServiceTest {
         
         // Then: Should calculate risk score
         Assert.areNotEqual(null, score, 'Risk score should not be null');
-        System.assert(score >= 0 && score <= 10, 'Risk score should be between 0 and 10');
+        Assert.isTrue(score >= 0 && score <= 10, 'Risk score should be between 0 and 10');
     }
     
     @IsTest

--- a/force-app/main/default/classes/ElaroCCPADataInventoryServiceTest.cls
+++ b/force-app/main/default/classes/ElaroCCPADataInventoryServiceTest.cls
@@ -79,9 +79,9 @@ private class ElaroCCPADataInventoryServiceTest {
         Assert.areNotEqual(null, report.reportDate, 'Report date should be set');
         Assert.areNotEqual(null, report.responseDeadline, 'Response deadline should be set');
         Assert.areEqual(true, report.doNotSellStatus, 'Should reflect opt-out status');
-        System.assert(!report.categoriesCollected.isEmpty(), 'Should have categories');
-        System.assert(!report.sources.isEmpty(), 'Should have sources');
-        System.assert(!report.businessPurposes.isEmpty(), 'Should have business purposes');
+        Assert.isTrue(!report.categoriesCollected.isEmpty(), 'Should have categories');
+        Assert.isTrue(!report.sources.isEmpty(), 'Should have sources');
+        Assert.isTrue(!report.businessPurposes.isEmpty(), 'Should have business purposes');
         Assert.areNotEqual(null, report.requestId, 'Request ID should be set');
         
         // Verify audit log created
@@ -105,7 +105,7 @@ private class ElaroCCPADataInventoryServiceTest {
             Assert.fail( 'Should have thrown exception');
         } catch (ElaroCCPADataInventoryService.CCPAException e) {
             // Then: Exception should be thrown
-            System.assert(e.getMessage().contains('Contact not found'), 
+            Assert.isTrue(e.getMessage().contains('Contact not found'), 
                 'Error message should indicate contact not found');
         }
         Test.stopTest();
@@ -153,7 +153,7 @@ private class ElaroCCPADataInventoryServiceTest {
             } catch (Exception e) {
                 // Then: Permission exception should be thrown
                 // Note: InsufficientAccessException may not be available, catch generic Exception
-                System.assert(e.getMessage().contains('insufficient') || 
+                Assert.isTrue(e.getMessage().contains('insufficient') || 
                     e.getMessage().contains('access') || 
                     e.getMessage().contains('permission'), 
                     'Should throw permission-related exception: ' + e.getMessage());
@@ -172,9 +172,9 @@ private class ElaroCCPADataInventoryServiceTest {
         Test.stopTest();
         
         // Then: Should return pending requests
-        System.assert(!requests.isEmpty(), 'Should return pending requests');
+        Assert.isTrue(!requests.isEmpty(), 'Should return pending requests');
         for (CCPA_Request__c req : requests) {
-            System.assert(req.Status__c == 'Pending' || req.Status__c == 'In Progress', 
+            Assert.isTrue(req.Status__c == 'Pending' || req.Status__c == 'In Progress', 
                 'Should only return pending/in progress requests');
         }
     }
@@ -276,8 +276,8 @@ private class ElaroCCPADataInventoryServiceTest {
         // Then: Report should still be generated with available data
         Assert.areNotEqual(null, report, 'Report should be generated');
         Assert.areEqual('minimal@test.com', report.dataSubject, 'Should have email');
-        System.assert(report.specificData.containsKey('Email Address'), 'Should have email data point');
-        System.assert(!report.specificData.containsKey('Mailing Address'), 'Should not have mailing address');
+        Assert.isTrue(report.specificData.containsKey('Email Address'), 'Should have email data point');
+        Assert.isTrue(!report.specificData.containsKey('Mailing Address'), 'Should not have mailing address');
     }
 
     @IsTest
@@ -338,8 +338,8 @@ private class ElaroCCPADataInventoryServiceTest {
 
         // Then: Third parties should be populated
         Assert.areNotEqual(null, report.thirdParties, 'Should have third parties list');
-        System.assert(!report.thirdParties.isEmpty(), 'Third parties should not be empty');
-        System.assert(report.thirdParties.size() >= 3, 'Should have at least 3 third parties');
+        Assert.isTrue(!report.thirdParties.isEmpty(), 'Third parties should not be empty');
+        Assert.isTrue(report.thirdParties.size() >= 3, 'Should have at least 3 third parties');
     }
 
     @IsTest
@@ -406,7 +406,7 @@ private class ElaroCCPADataInventoryServiceTest {
             ElaroCCPADataInventoryService.processDoNotSellRequest(invalidContactId);
             Assert.fail( 'Should have thrown exception');
         } catch (ElaroCCPADataInventoryService.CCPAException e) {
-            System.assert(e.getMessage().contains('Contact not found'),
+            Assert.isTrue(e.getMessage().contains('Contact not found'),
                 'Error message should indicate contact not found');
         }
         Test.stopTest();
@@ -423,10 +423,10 @@ private class ElaroCCPADataInventoryServiceTest {
         Test.stopTest();
 
         // Then: All data points should be present
-        System.assert(report.specificData.containsKey('Full Name'), 'Should have full name');
-        System.assert(report.specificData.containsKey('Email Address'), 'Should have email');
-        System.assert(report.specificData.containsKey('Phone Number'), 'Should have phone');
-        System.assert(report.specificData.containsKey('Mailing Address'), 'Should have mailing address');
+        Assert.isTrue(report.specificData.containsKey('Full Name'), 'Should have full name');
+        Assert.isTrue(report.specificData.containsKey('Email Address'), 'Should have email');
+        Assert.isTrue(report.specificData.containsKey('Phone Number'), 'Should have phone');
+        Assert.isTrue(report.specificData.containsKey('Mailing Address'), 'Should have mailing address');
     }
 
     @IsTest

--- a/force-app/main/default/classes/ElaroCCPASLAMonitorSchedulerTest.cls
+++ b/force-app/main/default/classes/ElaroCCPASLAMonitorSchedulerTest.cls
@@ -93,7 +93,7 @@ private class ElaroCCPASLAMonitorSchedulerTest {
             SELECT Id, Status__c FROM CCPA_Request__c
             WHERE Status__c = 'Overdue'
         ];
-        System.assert(overdueRequests.size() > 0, 'Overdue requests should be marked');
+        Assert.isTrue(overdueRequests.size() > 0, 'Overdue requests should be marked');
     }
 
     @isTest

--- a/force-app/main/default/classes/ElaroChangeAdvisorTest.cls
+++ b/force-app/main/default/classes/ElaroChangeAdvisorTest.cls
@@ -14,9 +14,9 @@ private class ElaroChangeAdvisorTest {
         
         Assert.areNotEqual(null, impact, 'Should return impact analysis');
         Assert.areNotEqual(null, impact.frameworkImpact, 'Should have framework impact');
-        System.assert(impact.overallImpact < 0, 'Should show negative impact');
+        Assert.isTrue(impact.overallImpact < 0, 'Should show negative impact');
         Assert.areNotEqual(null, impact.alternatives, 'Should provide alternatives');
-        System.assert(!impact.alternatives.isEmpty(), 'Should have at least one alternative');
+        Assert.isTrue(!impact.alternatives.isEmpty(), 'Should have at least one alternative');
     }
     
     @isTest
@@ -31,7 +31,7 @@ private class ElaroChangeAdvisorTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, impact, 'Should return impact analysis');
-        System.assert(impact.frameworkImpact.containsKey('HIPAA'), 'Should include HIPAA impact');
+        Assert.isTrue(impact.frameworkImpact.containsKey('HIPAA'), 'Should include HIPAA impact');
     }
     
     @isTest

--- a/force-app/main/default/classes/ElaroClaudeAPIMockTest.cls
+++ b/force-app/main/default/classes/ElaroClaudeAPIMockTest.cls
@@ -25,8 +25,8 @@ private class ElaroClaudeAPIMockTest {
         
         // Verify response
         Assert.areEqual(200, res.getStatusCode(), 'Should return 200 for success');
-        System.assert(res.getBody().contains('recommendation'), 'Should contain recommendation in response');
-        System.assert(res.getBody().contains('claude-sonnet'), 'Should contain model information');
+        Assert.isTrue(res.getBody().contains('recommendation'), 'Should contain recommendation in response');
+        Assert.isTrue(res.getBody().contains('claude-sonnet'), 'Should contain model information');
     }
     
     @isTest
@@ -47,7 +47,7 @@ private class ElaroClaudeAPIMockTest {
         
         // Verify error response
         Assert.areEqual(400, res.getStatusCode(), 'Should return 400 for error');
-        System.assert(res.getBody().contains('invalid_request_error'), 'Should contain error type');
+        Assert.isTrue(res.getBody().contains('invalid_request_error'), 'Should contain error type');
     }
     
     @isTest
@@ -65,7 +65,7 @@ private class ElaroClaudeAPIMockTest {
         Test.stopTest();
         
         Assert.areEqual(429, res.getStatusCode(), 'Should return 429 for rate limit');
-        System.assert(res.getBody().contains('rate_limit_error'), 'Should indicate rate limiting');
+        Assert.isTrue(res.getBody().contains('rate_limit_error'), 'Should indicate rate limiting');
     }
     
     @isTest
@@ -83,7 +83,7 @@ private class ElaroClaudeAPIMockTest {
         Test.stopTest();
         
         Assert.areEqual(504, res.getStatusCode(), 'Should return 504 for timeout');
-        System.assert(res.getBody().contains('timeout_error'), 'Should indicate timeout');
+        Assert.isTrue(res.getBody().contains('timeout_error'), 'Should indicate timeout');
     }
     
     @isTest

--- a/force-app/main/default/classes/ElaroComplianceAlertTest.cls
+++ b/force-app/main/default/classes/ElaroComplianceAlertTest.cls
@@ -79,7 +79,7 @@ private class ElaroComplianceAlertTest {
         
         Assert.areEqual('Test Alert Config', alertConfig.Name, 'Name should match');
         Assert.areEqual(75, alertConfig.Threshold__c, 'Threshold should match');
-        System.assert(alertConfig.Channels__c.contains('EMAIL'), 'Should include EMAIL channel');
+        Assert.isTrue(alertConfig.Channels__c.contains('EMAIL'), 'Should include EMAIL channel');
     }
     
     @isTest
@@ -94,7 +94,7 @@ private class ElaroComplianceAlertTest {
             ElaroComplianceAlert.configureAlert(config);
             Assert.fail( 'Should throw exception for missing name');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('name'), 'Should mention name requirement');
+            Assert.isTrue(e.getMessage().contains('name'), 'Should mention name requirement');
         }
         Test.stopTest();
     }
@@ -111,7 +111,7 @@ private class ElaroComplianceAlertTest {
             ElaroComplianceAlert.configureAlert(config);
             Assert.fail( 'Should throw exception for invalid threshold');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Threshold'), 'Should mention threshold requirement');
+            Assert.isTrue(e.getMessage().contains('Threshold'), 'Should mention threshold requirement');
         }
         Test.stopTest();
     }
@@ -128,7 +128,7 @@ private class ElaroComplianceAlertTest {
             ElaroComplianceAlert.configureAlert(config);
             Assert.fail( 'Should throw exception for empty channels');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('channel'), 'Should mention channel requirement');
+            Assert.isTrue(e.getMessage().contains('channel'), 'Should mention channel requirement');
         }
         Test.stopTest();
     }
@@ -336,7 +336,7 @@ private class ElaroComplianceAlertTest {
         Test.stopTest();
         
         // Should have at least the pending review items from setup
-        System.assert(alerts.size() >= 0, 'Should return alerts if available');
+        Assert.isTrue(alerts.size() >= 0, 'Should return alerts if available');
     }
     
     // ═══════════════════════════════════════════════════════════════
@@ -433,7 +433,7 @@ private class ElaroComplianceAlertTest {
             }
         }
         
-        System.assert(triggeredCount > 0, 'Should trigger some alerts');
+        Assert.isTrue(triggeredCount > 0, 'Should trigger some alerts');
     }
     
     // ═══════════════════════════════════════════════════════════════

--- a/force-app/main/default/classes/ElaroComplianceCopilotServiceTest.cls
+++ b/force-app/main/default/classes/ElaroComplianceCopilotServiceTest.cls
@@ -37,7 +37,7 @@ private class ElaroComplianceCopilotServiceTest {
         Assert.areNotEqual(null, rec, 'Should return recommendation');
         Assert.areNotEqual(null, rec.recommendation, 'Should have recommendation text');
         Assert.areNotEqual(null, rec.severity, 'Should have severity');
-        System.assert(rec.confidence &gt;= 0 &amp;&amp; rec.confidence &lt;= 100, 'Confidence should be 0-100');
+        Assert.isTrue(rec.confidence &gt;= 0 &amp;&amp; rec.confidence &lt;= 100, 'Confidence should be 0-100');
     }
     
     @isTest
@@ -50,7 +50,7 @@ private class ElaroComplianceCopilotServiceTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, rec, 'Should return recommendation even for empty list');
-        System.assert(rec.recommendation.contains('No events'), 'Should indicate no events');
+        Assert.isTrue(rec.recommendation.contains('No events'), 'Should indicate no events');
     }
     
     @isTest
@@ -80,7 +80,7 @@ private class ElaroComplianceCopilotServiceTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, summary, 'Should return summary');
-        System.assert(summary.length() &gt; 0, 'Summary should not be empty');
+        Assert.isTrue(summary.length() &gt; 0, 'Summary should not be empty');
     }
     
     @isTest
@@ -92,7 +92,7 @@ private class ElaroComplianceCopilotServiceTest {
             ElaroComplianceCopilotService.generateAuditSummary(null);
             Assert.fail( 'Should throw exception');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should mention required');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should mention required');
         }
         Test.stopTest();
     }
@@ -106,7 +106,7 @@ private class ElaroComplianceCopilotServiceTest {
             ElaroComplianceCopilotService.generateAuditSummary('');
             Assert.fail( 'Should throw exception');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should mention required');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should mention required');
         }
         Test.stopTest();
     }
@@ -137,7 +137,7 @@ private class ElaroComplianceCopilotServiceTest {
             ElaroComplianceCopilotService.predictComplianceRisks(null);
             Assert.fail( 'Should throw exception');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should mention required');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should mention required');
         }
         Test.stopTest();
     }

--- a/force-app/main/default/classes/ElaroComplianceCopilotTest.cls
+++ b/force-app/main/default/classes/ElaroComplianceCopilotTest.cls
@@ -28,9 +28,9 @@ private class ElaroComplianceCopilotTest {
         Assert.areNotEqual(null, response, 'Response should not be null');
         Assert.areEqual('DEEP_ANALYSIS', response.queryType, 'Query type should be DEEP_ANALYSIS');
         Assert.areNotEqual(null, response.answer, 'Answer should not be null');
-        System.assert(response.answer.length() > 0, 'Answer should not be empty');
+        Assert.isTrue(response.answer.length() > 0, 'Answer should not be empty');
         Assert.areNotEqual(null, response.confidence, 'Confidence should not be null');
-        System.assert(response.confidence >= 0 && response.confidence <= 1, 'Confidence should be between 0 and 1');
+        Assert.isTrue(response.confidence >= 0 && response.confidence <= 1, 'Confidence should be between 0 and 1');
     }
     
     @IsTest
@@ -43,7 +43,7 @@ private class ElaroComplianceCopilotTest {
         Assert.areNotEqual(null, response, 'Response should not be null');
         Assert.areEqual('DEEP_ANALYSIS', response.queryType, 'Query type should be DEEP_ANALYSIS');
         Assert.areNotEqual(null, response.answer, 'Answer should not be null');
-        System.assert(response.answer.length() > 0, 'Answer should not be empty');
+        Assert.isTrue(response.answer.length() > 0, 'Answer should not be empty');
     }
     
     @IsTest
@@ -69,7 +69,7 @@ private class ElaroComplianceCopilotTest {
         
         Assert.areNotEqual(null, response, 'Response should not be null');
         Assert.areNotEqual(null, response.answer, 'Answer should not be null');
-        System.assert(response.answer.contains('Please provide a topic'), 'Should request topic input');
+        Assert.isTrue(response.answer.contains('Please provide a topic'), 'Should request topic input');
         Assert.areEqual(0.0, response.confidence, 'Confidence should be 0 for invalid input');
     }
     
@@ -82,7 +82,7 @@ private class ElaroComplianceCopilotTest {
         
         Assert.areNotEqual(null, response, 'Response should not be null');
         Assert.areNotEqual(null, response.answer, 'Answer should not be null');
-        System.assert(response.answer.contains('Please provide a topic'), 'Should request topic input');
+        Assert.isTrue(response.answer.contains('Please provide a topic'), 'Should request topic input');
         Assert.areEqual(0.0, response.confidence, 'Confidence should be 0 for invalid input');
     }
     
@@ -100,7 +100,7 @@ private class ElaroComplianceCopilotTest {
         Assert.areNotEqual(null, response, 'Response should not be null');
         // The method may catch the exception and return an error response
         // Check that response indicates an issue
-        System.assert(response.answer != null, 'Answer should not be null');
+        Assert.isTrue(response.answer != null, 'Answer should not be null');
     }
     
     @IsTest
@@ -122,7 +122,7 @@ private class ElaroComplianceCopilotTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, response.answer, 'Answer should not be null');
-        System.assert(response.answer.contains('Recommendations'), 'Answer should include recommendations');
+        Assert.isTrue(response.answer.contains('Recommendations'), 'Answer should include recommendations');
     }
     
     @IsTest
@@ -135,7 +135,7 @@ private class ElaroComplianceCopilotTest {
         Assert.areNotEqual(null, response.actions, 'Actions should not be null');
         // Export action is added in the method, verify actions list exists
         // May be empty if method fails, but list should exist
-        System.assert(response.actions.size() >= 0, 'Actions list should exist');
+        Assert.isTrue(response.actions.size() >= 0, 'Actions list should exist');
     }
     
     @IsTest
@@ -173,11 +173,11 @@ private class ElaroComplianceCopilotTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, commands, 'Commands should not be null');
-        System.assert(!commands.isEmpty(), 'Should return at least one command');
+        Assert.isTrue(!commands.isEmpty(), 'Should return at least one command');
         
         for (Map<String, String> cmd : commands) {
-            System.assert(cmd.containsKey('command'), 'Command should have command key');
-            System.assert(cmd.containsKey('icon'), 'Command should have icon key');
+            Assert.isTrue(cmd.containsKey('command'), 'Command should have command key');
+            Assert.isTrue(cmd.containsKey('icon'), 'Command should have icon key');
         }
     }
 }

--- a/force-app/main/default/classes/ElaroComplianceScorerTest.cls
+++ b/force-app/main/default/classes/ElaroComplianceScorerTest.cls
@@ -18,7 +18,7 @@ private class ElaroComplianceScorerTest {
 
         Assert.areNotEqual(null, result, 'Should return a result');
         Assert.areNotEqual(null, result.overallScore, 'Should have an overall score');
-        System.assert(result.overallScore >= 0 && result.overallScore <= 100, 'Score should be between 0 and 100');
+        Assert.isTrue(result.overallScore >= 0 && result.overallScore <= 100, 'Score should be between 0 and 100');
         Assert.areNotEqual(null, result.rating, 'Should have a rating');
         Assert.areNotEqual(null, result.frameworkScores, 'Should have framework scores');
     }
@@ -40,9 +40,9 @@ private class ElaroComplianceScorerTest {
         ElaroComplianceScorer.ScoreResult result = ElaroComplianceScorer.calculateReadinessScore();
         Test.stopTest();
 
-        System.assert(result.overallScore > 0, 'Should have positive score with documented permission sets');
+        Assert.isTrue(result.overallScore > 0, 'Should have positive score with documented permission sets');
         Assert.areNotEqual(null, result.factors, 'Should have score factors');
-        System.assert(!result.factors.isEmpty(), 'Should have at least one factor');
+        Assert.isTrue(!result.factors.isEmpty(), 'Should have at least one factor');
     }
     
     @IsTest
@@ -63,7 +63,7 @@ private class ElaroComplianceScorerTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, result, 'Should return a result even with bulk data');
-        System.assert(result.overallScore >= 0 && result.overallScore <= 100, 'Score should be valid');
+        Assert.isTrue(result.overallScore >= 0 && result.overallScore <= 100, 'Score should be valid');
     }
     
     @IsTest

--- a/force-app/main/default/classes/ElaroConsentWithdrawalHandlerTest.cls
+++ b/force-app/main/default/classes/ElaroConsentWithdrawalHandlerTest.cls
@@ -230,6 +230,6 @@ private class ElaroConsentWithdrawalHandlerTest {
 
         // Verify withdrawal processing completed with event publishing
         // Platform events are async, verify DML occurred for updates
-        System.assert(Limits.getDmlStatements() > 0, 'Should publish events and update records');
+        Assert.isTrue(Limits.getDmlStatements() > 0, 'Should publish events and update records');
     }
 }

--- a/force-app/main/default/classes/ElaroConstantsTest.cls
+++ b/force-app/main/default/classes/ElaroConstantsTest.cls
@@ -20,8 +20,8 @@ private class ElaroConstantsTest {
         
         // Verify ALL_FRAMEWORKS contains all frameworks (10 total: HIPAA, SOC2, NIST, FedRAMP, GDPR, SOX, PCI-DSS, CCPA, GLBA, ISO27001)
         Assert.areEqual(10, ElaroConstants.ALL_FRAMEWORKS.size(), 'ALL_FRAMEWORKS should contain 10 frameworks');
-        System.assert(ElaroConstants.ALL_FRAMEWORKS.contains('HIPAA'), 'ALL_FRAMEWORKS should contain HIPAA');
-        System.assert(ElaroConstants.ALL_FRAMEWORKS.contains('SOC2'), 'ALL_FRAMEWORKS should contain SOC2');
+        Assert.isTrue(ElaroConstants.ALL_FRAMEWORKS.contains('HIPAA'), 'ALL_FRAMEWORKS should contain HIPAA');
+        Assert.isTrue(ElaroConstants.ALL_FRAMEWORKS.contains('SOC2'), 'ALL_FRAMEWORKS should contain SOC2');
     }
     
     @IsTest
@@ -118,17 +118,17 @@ private class ElaroConstantsTest {
     @IsTest
     static void testIsValidFramework() {
         // Valid frameworks
-        System.assert(ElaroConstants.isValidFramework('HIPAA'), 'HIPAA should be valid');
-        System.assert(ElaroConstants.isValidFramework('hipaa'), 'hipaa (lowercase) should be valid');
-        System.assert(ElaroConstants.isValidFramework('SOC2'), 'SOC2 should be valid');
-        System.assert(ElaroConstants.isValidFramework('NIST'), 'NIST should be valid');
-        System.assert(ElaroConstants.isValidFramework('FedRAMP'), 'FedRAMP should be valid');
-        System.assert(ElaroConstants.isValidFramework('GDPR'), 'GDPR should be valid');
+        Assert.isTrue(ElaroConstants.isValidFramework('HIPAA'), 'HIPAA should be valid');
+        Assert.isTrue(ElaroConstants.isValidFramework('hipaa'), 'hipaa (lowercase) should be valid');
+        Assert.isTrue(ElaroConstants.isValidFramework('SOC2'), 'SOC2 should be valid');
+        Assert.isTrue(ElaroConstants.isValidFramework('NIST'), 'NIST should be valid');
+        Assert.isTrue(ElaroConstants.isValidFramework('FedRAMP'), 'FedRAMP should be valid');
+        Assert.isTrue(ElaroConstants.isValidFramework('GDPR'), 'GDPR should be valid');
         
         // Invalid frameworks
-        System.assert(!ElaroConstants.isValidFramework(null), 'Null should be invalid');
-        System.assert(!ElaroConstants.isValidFramework(''), 'Empty string should be invalid');
-        System.assert(!ElaroConstants.isValidFramework('INVALID'), 'INVALID should be invalid');
+        Assert.isTrue(!ElaroConstants.isValidFramework(null), 'Null should be invalid');
+        Assert.isTrue(!ElaroConstants.isValidFramework(''), 'Empty string should be invalid');
+        Assert.isTrue(!ElaroConstants.isValidFramework('INVALID'), 'INVALID should be invalid');
     }
     
     @IsTest

--- a/force-app/main/default/classes/ElaroDailyDigestTest.cls
+++ b/force-app/main/default/classes/ElaroDailyDigestTest.cls
@@ -77,7 +77,7 @@ private class ElaroDailyDigestTest {
         ];
         
         Assert.areEqual(cronExpression, ct.CronExpression, 'Cron expression should match');
-        System.assert(ct.CronJobDetail.Name.contains('Elaro_Daily_Digest_'), 
+        Assert.isTrue(ct.CronJobDetail.Name.contains('Elaro_Daily_Digest_'), 
             'Job name should contain Elaro_Daily_Digest_');
     }
     
@@ -177,7 +177,7 @@ private class ElaroDailyDigestTest {
         
         Assert.areNotEqual(null, digest.statistics, 'Should have statistics');
         Assert.areNotEqual(null, digest.statistics.totalEvents, 'Should have total events');
-        System.assert(digest.statistics.totalEvents >= 0, 'Total events should be non-negative');
+        Assert.isTrue(digest.statistics.totalEvents >= 0, 'Total events should be non-negative');
         Assert.areNotEqual(null, digest.statistics.eventsByType, 'Should have events by type');
     }
     
@@ -226,7 +226,7 @@ private class ElaroDailyDigestTest {
         
         // Verify bulk data is handled
         ElaroDailyDigest.DigestData digest = ElaroDailyDigest.getDigestPreview();
-        System.assert(digest.statistics.totalEvents >= 200, 'Should count all evidence items');
+        Assert.isTrue(digest.statistics.totalEvents >= 200, 'Should count all evidence items');
     }
     
     // ═══════════════════════════════════════════════════════════════
@@ -276,7 +276,7 @@ private class ElaroDailyDigestTest {
         Assert.areNotEqual(null, digest.generatedAt, 'Should have generatedAt');
         Assert.areNotEqual(null, digest.periodStart, 'Should have periodStart');
         Assert.areNotEqual(null, digest.periodEnd, 'Should have periodEnd');
-        System.assert(digest.periodStart <= digest.periodEnd, 'Period start should be before end');
+        Assert.isTrue(digest.periodStart <= digest.periodEnd, 'Period start should be before end');
         Assert.areNotEqual(null, digest.trendingUp, 'Should have trendingUp');
         Assert.areNotEqual(null, digest.trendingDown, 'Should have trendingDown');
     }

--- a/force-app/main/default/classes/ElaroDashboardControllerTest.cls
+++ b/force-app/main/default/classes/ElaroDashboardControllerTest.cls
@@ -76,7 +76,7 @@ private class ElaroDashboardControllerTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, packages, 'Packages should not be null');
-        System.assert(packages.size() > 0, 'Should return at least one package');
+        Assert.isTrue(packages.size() > 0, 'Should return at least one package');
     }
     
     @IsTest
@@ -117,8 +117,8 @@ private class ElaroDashboardControllerTest {
         
         Assert.areNotEqual(null, stats, 'Stats should not be null');
         Assert.areEqual(pkg.Id, stats.id, 'Package ID should match');
-        System.assert(stats.mappingCount > 0, 'Should have mappings');
-        System.assert(stats.evidenceCount > 0, 'Should have evidence');
+        Assert.isTrue(stats.mappingCount > 0, 'Should have mappings');
+        Assert.isTrue(stats.evidenceCount > 0, 'Should have evidence');
     }
     
     @IsTest
@@ -128,7 +128,7 @@ private class ElaroDashboardControllerTest {
             ElaroDashboardController.getAuditPackageStats('');
             Assert.fail( 'Should have thrown AuraHandledException');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('blank'), 'Should mention blank ID');
+            Assert.isTrue(e.getMessage().contains('blank'), 'Should mention blank ID');
         }
         Test.stopTest();
     }

--- a/force-app/main/default/classes/ElaroDeliveryServiceTest.cls
+++ b/force-app/main/default/classes/ElaroDeliveryServiceTest.cls
@@ -54,7 +54,7 @@ private class ElaroDeliveryServiceTest {
             ElaroDeliveryService.deliverAuditPackage(null, new List&lt;String&gt;{'test@example.com'});
             Assert.fail( 'Should throw exception');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should mention required fields');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should mention required fields');
         }
         Test.stopTest();
     }
@@ -68,7 +68,7 @@ private class ElaroDeliveryServiceTest {
             ElaroDeliveryService.deliverAuditPackage(pkg.Id, new List&lt;String&gt;());
             Assert.fail( 'Should throw exception');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should mention required fields');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should mention required fields');
         }
         Test.stopTest();
     }
@@ -82,7 +82,7 @@ private class ElaroDeliveryServiceTest {
             ElaroDeliveryService.deliverAuditPackage(pkg.Id, null);
             Assert.fail( 'Should throw exception');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should mention required fields');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should mention required fields');
         }
         Test.stopTest();
     }
@@ -132,7 +132,7 @@ private class ElaroDeliveryServiceTest {
             );
             Assert.fail( 'Should throw exception');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Cron expression'), 'Should mention cron expression');
+            Assert.isTrue(e.getMessage().contains('Cron expression'), 'Should mention cron expression');
         }
         Test.stopTest();
     }
@@ -150,7 +150,7 @@ private class ElaroDeliveryServiceTest {
             );
             Assert.fail( 'Should throw exception');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Cron expression'), 'Should mention cron expression');
+            Assert.isTrue(e.getMessage().contains('Cron expression'), 'Should mention cron expression');
         }
         Test.stopTest();
     }
@@ -175,7 +175,7 @@ private class ElaroDeliveryServiceTest {
             FROM ContentDistribution
             WHERE Name LIKE '%Audit Package Share%'
         ];
-        System.assert(!distributions.isEmpty(), 'ContentDistribution should be created');
+        Assert.isTrue(!distributions.isEmpty(), 'ContentDistribution should be created');
         Assert.areEqual(Date.today().addDays(30), distributions[0].ExpiryDate, 'Expiration should be 30 days');
         Assert.areEqual(true, distributions[0].PreferencesPasswordRequired, 'Should require password');
     }
@@ -259,7 +259,7 @@ private class ElaroDeliveryServiceTest {
         List&lt;Map&lt;String, Object&gt;&gt; history = ElaroDeliveryService.getDeliveryHistory(pkg.Id);
         Test.stopTest();
         
-        System.assert(!history.isEmpty(), 'Should return delivery history');
+        Assert.isTrue(!history.isEmpty(), 'Should return delivery history');
     }
     
     @isTest

--- a/force-app/main/default/classes/ElaroDormantAccountAlertSchedulerTest.cls
+++ b/force-app/main/default/classes/ElaroDormantAccountAlertSchedulerTest.cls
@@ -77,7 +77,7 @@ private class ElaroDormantAccountAlertSchedulerTest {
         // Assert - check if any access reviews were created
         Integer reviewCount = [SELECT COUNT() FROM Access_Review__c WHERE Review_Type__c = 'Termination Review'];
         // Note: Count may vary based on org's user data
-        System.assert(reviewCount >= 0, 'Access review query should succeed');
+        Assert.isTrue(reviewCount >= 0, 'Access review query should succeed');
     }
 
     @isTest

--- a/force-app/main/default/classes/ElaroDrillDownControllerTest.cls
+++ b/force-app/main/default/classes/ElaroDrillDownControllerTest.cls
@@ -111,7 +111,7 @@ private class ElaroDrillDownControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for empty context');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for empty context');
     }
 
     @isTest
@@ -124,7 +124,7 @@ private class ElaroDrillDownControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for null context');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for null context');
     }
 
     @isTest
@@ -137,7 +137,7 @@ private class ElaroDrillDownControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for invalid JSON');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for invalid JSON');
     }
 
     @isTest
@@ -158,7 +158,7 @@ private class ElaroDrillDownControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for invalid object');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for invalid object');
     }
 
     @isTest
@@ -257,7 +257,7 @@ private class ElaroDrillDownControllerTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, csv, 'CSV should not be null');
-        System.assert(csv.contains('Name'), 'CSV should contain headers');
+        Assert.isTrue(csv.contains('Name'), 'CSV should contain headers');
     }
 
     @isTest
@@ -270,7 +270,7 @@ private class ElaroDrillDownControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for empty context');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for empty context');
     }
 
     @isTest
@@ -283,7 +283,7 @@ private class ElaroDrillDownControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for null context');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for null context');
     }
 
     @isTest
@@ -296,7 +296,7 @@ private class ElaroDrillDownControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for invalid JSON');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for invalid JSON');
     }
 
     @isTest

--- a/force-app/main/default/classes/ElaroDynamicReportControllerTest.cls
+++ b/force-app/main/default/classes/ElaroDynamicReportControllerTest.cls
@@ -47,7 +47,7 @@ private class ElaroDynamicReportControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for invalid object');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for invalid object');
     }
 
     @isTest
@@ -124,7 +124,7 @@ private class ElaroDynamicReportControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for invalid object');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for invalid object');
     }
 
     @isTest
@@ -137,7 +137,7 @@ private class ElaroDynamicReportControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for empty config');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for empty config');
     }
 
     @isTest
@@ -150,7 +150,7 @@ private class ElaroDynamicReportControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for null config');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for null config');
     }
 
     @isTest
@@ -163,7 +163,7 @@ private class ElaroDynamicReportControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for invalid JSON');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for invalid JSON');
     }
 
     @isTest
@@ -183,7 +183,7 @@ private class ElaroDynamicReportControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for empty fields');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for empty fields');
     }
 
     @isTest
@@ -203,7 +203,7 @@ private class ElaroDynamicReportControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for null fields');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for null fields');
     }
 
     @isTest
@@ -223,7 +223,7 @@ private class ElaroDynamicReportControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for invalid field');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for invalid field');
     }
 
     @isTest
@@ -249,7 +249,7 @@ private class ElaroDynamicReportControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for invalid operator');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for invalid operator');
     }
 
     @isTest
@@ -269,7 +269,7 @@ private class ElaroDynamicReportControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for max rows exceeded');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for max rows exceeded');
     }
 
     @isTest
@@ -611,6 +611,6 @@ private class ElaroDynamicReportControllerTest {
             new ElaroDynamicReportController.FieldMetadata();
         fm2.label = 'Beta';
 
-        System.assert(fm1.compareTo(fm2) < 0, 'Alpha should be before Beta');
+        Assert.isTrue(fm1.compareTo(fm2) < 0, 'Alpha should be before Beta');
     }
 }

--- a/force-app/main/default/classes/ElaroEventParserTest.cls
+++ b/force-app/main/default/classes/ElaroEventParserTest.cls
@@ -37,9 +37,9 @@ private class ElaroEventParserTest {
         Test.stopTest();
         
         String geoLocation = (String)parsed.get('geoLocation');
-        System.assert(geoLocation.contains('San Francisco'), 'Should contain city');
-        System.assert(geoLocation.contains('California'), 'Should contain state');
-        System.assert(geoLocation.contains('United States'), 'Should contain country');
+        Assert.isTrue(geoLocation.contains('San Francisco'), 'Should contain city');
+        Assert.isTrue(geoLocation.contains('California'), 'Should contain state');
+        Assert.isTrue(geoLocation.contains('United States'), 'Should contain country');
     }
     
     @isTest

--- a/force-app/main/default/classes/ElaroExecutiveKPIControllerTest.cls
+++ b/force-app/main/default/classes/ElaroExecutiveKPIControllerTest.cls
@@ -50,7 +50,7 @@ private class ElaroExecutiveKPIControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for blank name');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for blank name');
     }
 
     @isTest
@@ -63,7 +63,7 @@ private class ElaroExecutiveKPIControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for null name');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for null name');
     }
 
     @isTest
@@ -76,7 +76,7 @@ private class ElaroExecutiveKPIControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for non-existent KPI');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for non-existent KPI');
     }
 
     @isTest
@@ -91,7 +91,7 @@ private class ElaroExecutiveKPIControllerTest {
         }
         Test.stopTest();
         // Should either throw not found or sanitize the input
-        System.assert(exceptionThrown, 'Should have thrown exception or sanitized input');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception or sanitized input');
     }
 
     @isTest
@@ -104,7 +104,7 @@ private class ElaroExecutiveKPIControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception (not found)');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception (not found)');
     }
 
     @isTest

--- a/force-app/main/default/classes/ElaroGDPRComplianceServiceTest.cls
+++ b/force-app/main/default/classes/ElaroGDPRComplianceServiceTest.cls
@@ -18,8 +18,8 @@ private class ElaroGDPRComplianceServiceTest {
         
         // Then: Should calculate risk score
         Assert.areNotEqual(null, score, 'Risk score should not be null');
-        System.assert(score >= 0 && score <= 10, 'Risk score should be between 0 and 10');
-        System.assert(score > 3.0, 'Personal data fields should have higher risk');
+        Assert.isTrue(score >= 0 && score <= 10, 'Risk score should be between 0 and 10');
+        Assert.isTrue(score > 3.0, 'Personal data fields should have higher risk');
     }
     
     @IsTest
@@ -33,7 +33,7 @@ private class ElaroGDPRComplianceServiceTest {
         Test.stopTest();
         
         // Then: Should return base risk score
-        System.assert(score >= 3.0 && score <= 10, 'Should return base or calculated risk score');
+        Assert.isTrue(score >= 3.0 && score <= 10, 'Should return base or calculated risk score');
     }
     
     @IsTest

--- a/force-app/main/default/classes/ElaroGDPRDataErasureServiceTest.cls
+++ b/force-app/main/default/classes/ElaroGDPRDataErasureServiceTest.cls
@@ -76,7 +76,7 @@ private class ElaroGDPRDataErasureServiceTest {
         Test.stopTest();
         
         // Then: Erasure should succeed
-        System.assert(result.success, 'Erasure should succeed');
+        Assert.isTrue(result.success, 'Erasure should succeed');
         Assert.areNotEqual(null, result.auditLogId, 'Audit log should be created');
         Assert.areNotEqual(null, result.message, 'Message should be provided');
         
@@ -110,7 +110,7 @@ private class ElaroGDPRDataErasureServiceTest {
             Assert.fail( 'Should have thrown exception');
         } catch (ElaroGDPRDataErasureService.GDPRException e) {
             // Then: Exception should be thrown
-            System.assert(e.getMessage().contains('Contact not found'), 
+            Assert.isTrue(e.getMessage().contains('Contact not found'), 
                 'Error message should indicate contact not found');
         }
         Test.stopTest();
@@ -143,8 +143,8 @@ private class ElaroGDPRDataErasureServiceTest {
         
         // Then: Should not be able to erase
         Assert.areEqual(false, result.canErase, 'Should not be able to erase');
-        System.assert(!result.blockers.isEmpty(), 'Blockers should exist');
-        System.assert(result.blockers[0].contains('open case'), 
+        Assert.isTrue(!result.blockers.isEmpty(), 'Blockers should exist');
+        Assert.isTrue(result.blockers[0].contains('open case'), 
             'Blocker should mention open case');
     }
     
@@ -165,7 +165,7 @@ private class ElaroGDPRDataErasureServiceTest {
             } catch (Exception e) {
                 // Then: Permission exception should be thrown
                 // Note: InsufficientAccessException may not be available, catch generic Exception
-                System.assert(e.getMessage().contains('insufficient') || 
+                Assert.isTrue(e.getMessage().contains('insufficient') || 
                     e.getMessage().contains('access') || 
                     e.getMessage().contains('permission'), 
                     'Should throw permission-related exception: ' + e.getMessage());
@@ -189,7 +189,7 @@ private class ElaroGDPRDataErasureServiceTest {
         Test.stopTest();
         
         // Then: Should return requests
-        System.assert(!requests.isEmpty(), 'Should return at least one request');
+        Assert.isTrue(!requests.isEmpty(), 'Should return at least one request');
         Assert.areEqual(testContact.Email, requests[0].Contact_Email__c, 
             'Should match contact email');
     }
@@ -324,7 +324,7 @@ private class ElaroGDPRDataErasureServiceTest {
             FROM GDPR_Erasure_Request__c
             WHERE Id = :result.auditLogId
         ];
-        System.assert(auditLog.Records_Deleted__c >= 3,
+        Assert.isTrue(auditLog.Records_Deleted__c >= 3,
             'Should count contact + task + event as deleted');
     }
 
@@ -446,7 +446,7 @@ private class ElaroGDPRDataErasureServiceTest {
         Assert.areEqual(testReason, auditLog.Request_Reason__c, 'Reason should match');
         Assert.areEqual('Completed', auditLog.Status__c, 'Status should be Completed');
         Assert.areEqual(UserInfo.getUserId(), auditLog.Requested_By__c, 'Requested by should match current user');
-        System.assert(auditLog.Records_Deleted__c >= 1, 'At least one record should be deleted');
+        Assert.isTrue(auditLog.Records_Deleted__c >= 1, 'At least one record should be deleted');
     }
 
     @IsTest

--- a/force-app/main/default/classes/ElaroGDPRDataPortabilityServiceTest.cls
+++ b/force-app/main/default/classes/ElaroGDPRDataPortabilityServiceTest.cls
@@ -44,7 +44,7 @@ private class ElaroGDPRDataPortabilityServiceTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, jsonData, 'Should return JSON data');
-        System.assert(jsonData.contains('contact'), 'Should contain contact data');
+        Assert.isTrue(jsonData.contains('contact'), 'Should contain contact data');
     }
 
     @IsTest
@@ -57,8 +57,8 @@ private class ElaroGDPRDataPortabilityServiceTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, jsonData, 'Should return JSON data');
-        System.assert(jsonData.length() > 0, 'Should have content');
-        System.assert(jsonData.contains('cases') || jsonData.contains('opportunities'), 
+        Assert.isTrue(jsonData.length() > 0, 'Should have content');
+        Assert.isTrue(jsonData.contains('cases') || jsonData.contains('opportunities'), 
             'Should include related data');
     }
 
@@ -91,7 +91,7 @@ private class ElaroGDPRDataPortabilityServiceTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, jsonData, 'Should export data');
-        System.assert(jsonData.length() > 0, 'Should have content');
+        Assert.isTrue(jsonData.length() > 0, 'Should have content');
     }
 
     @IsTest
@@ -105,7 +105,7 @@ private class ElaroGDPRDataPortabilityServiceTest {
 
         Assert.areNotEqual(null, jsonData, 'Should export data');
         // Verify it contains standard fields
-        System.assert(jsonData.contains('FirstName') || jsonData.contains('LastName') || 
+        Assert.isTrue(jsonData.contains('FirstName') || jsonData.contains('LastName') || 
             jsonData.contains('Email'), 'Should include standard contact fields');
     }
 
@@ -120,7 +120,7 @@ private class ElaroGDPRDataPortabilityServiceTest {
 
         Assert.areNotEqual(null, jsonData, 'Should return data');
         // JSON format is machine-readable and can be converted to CSV
-        System.assert(jsonData.contains('"') || jsonData.contains('{'), 
+        Assert.isTrue(jsonData.contains('"') || jsonData.contains('{'), 
             'Should be in structured format');
     }
 
@@ -160,7 +160,7 @@ private class ElaroGDPRDataPortabilityServiceTest {
         Test.stopTest();
 
         Assert.areEqual(200, exportedData.size(), 'Should export all 200 contacts');
-        System.assert(endQueries - startQueries < 100, 'Should be reasonably efficient');
+        Assert.isTrue(endQueries - startQueries < 100, 'Should be reasonably efficient');
     }
 
     @IsTest
@@ -174,7 +174,7 @@ private class ElaroGDPRDataPortabilityServiceTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, inventory, 'Should return inventory');
-        System.assert(inventory.containsKey('exportMetadata'), 'Should include export metadata');
-        System.assert(inventory.containsKey('personalInformation'), 'Should include personal information');
+        Assert.isTrue(inventory.containsKey('exportMetadata'), 'Should include export metadata');
+        Assert.isTrue(inventory.containsKey('personalInformation'), 'Should include personal information');
     }
 }

--- a/force-app/main/default/classes/ElaroGDPRExceptionTest.cls
+++ b/force-app/main/default/classes/ElaroGDPRExceptionTest.cls
@@ -61,12 +61,12 @@ private class ElaroGDPRExceptionTest {
             simulateGDPRFailure();
         } catch (ElaroGDPRException e) {
             exceptionCaught = true;
-            System.assert(e.getMessage().contains('Contact not found'), 'Message should indicate contact not found');
+            Assert.isTrue(e.getMessage().contains('Contact not found'), 'Message should indicate contact not found');
         }
 
         Test.stopTest();
 
-        System.assert(exceptionCaught, 'Exception should have been caught');
+        Assert.isTrue(exceptionCaught, 'Exception should have been caught');
     }
 
     @IsTest
@@ -77,8 +77,8 @@ private class ElaroGDPRExceptionTest {
 
         Test.stopTest();
 
-        System.assert(gdprEx instanceof Exception, 'Should be an Exception');
-        System.assert(gdprEx instanceof ElaroGDPRException, 'Should be a ElaroGDPRException');
+        Assert.isTrue(gdprEx instanceof Exception, 'Should be an Exception');
+        Assert.isTrue(gdprEx instanceof ElaroGDPRException, 'Should be a ElaroGDPRException');
     }
 
     @IsTest
@@ -90,7 +90,7 @@ private class ElaroGDPRExceptionTest {
         } catch (ElaroGDPRException e) {
             String stackTrace = e.getStackTraceString();
             Assert.areNotEqual(null, stackTrace, 'Stack trace should not be null');
-            System.assert(stackTrace.length() > 0, 'Stack trace should have content');
+            Assert.isTrue(stackTrace.length() > 0, 'Stack trace should have content');
         }
 
         Test.stopTest();
@@ -109,7 +109,7 @@ private class ElaroGDPRExceptionTest {
         } catch (ElaroGDPRException e) {
             Assert.areEqual('GDPR lookup failed', e.getMessage(), 'Outer message should match');
             Assert.areNotEqual(null, e.getCause(), 'Should have a cause');
-            System.assert(e.getCause() instanceof QueryException, 'Cause should be QueryException');
+            Assert.isTrue(e.getCause() instanceof QueryException, 'Cause should be QueryException');
         }
 
         Test.stopTest();

--- a/force-app/main/default/classes/ElaroGLBAAnnualNoticeBatchTest.cls
+++ b/force-app/main/default/classes/ElaroGLBAAnnualNoticeBatchTest.cls
@@ -125,7 +125,7 @@ private class ElaroGLBAAnnualNoticeBatchTest {
             WHERE Delivery_Status__c = 'Pending'
         ];
 
-        System.assert(pendingCount > 0, 'New pending notices should be created');
+        Assert.isTrue(pendingCount > 0, 'New pending notices should be created');
     }
 
     @IsTest

--- a/force-app/main/default/classes/ElaroGLBAAnnualNoticeSchedulerTest.cls
+++ b/force-app/main/default/classes/ElaroGLBAAnnualNoticeSchedulerTest.cls
@@ -68,7 +68,7 @@ private class ElaroGLBAAnnualNoticeSchedulerTest {
         ];
         
         // Note: In test context, batch jobs execute synchronously
-        System.assert(!jobs.isEmpty() || Test.isRunningTest(), 'Batch job should be queued or executed');
+        Assert.isTrue(!jobs.isEmpty() || Test.isRunningTest(), 'Batch job should be queued or executed');
     }
     
     @isTest
@@ -126,7 +126,7 @@ private class ElaroGLBAAnnualNoticeSchedulerTest {
             WHERE Id = :jobId
         ];
         
-        System.assert(ct.CronJobDetail.Name.contains('GLBA Annual Notice'), 
+        Assert.isTrue(ct.CronJobDetail.Name.contains('GLBA Annual Notice'), 
             'Job name should contain GLBA Annual Notice');
         Assert.areNotEqual(null, ct.CronExpression, 'Cron expression should be set');
     }
@@ -147,7 +147,7 @@ private class ElaroGLBAAnnualNoticeSchedulerTest {
         ];
         
         // Verify cron expression is valid (default: '0 0 6 * * ?')
-        System.assert(ct.CronExpression.contains('0 0 6') || ct.CronExpression.length() > 0, 
+        Assert.isTrue(ct.CronExpression.contains('0 0 6') || ct.CronExpression.length() > 0, 
             'Cron expression should be valid');
     }
     

--- a/force-app/main/default/classes/ElaroGLBAPrivacyNoticeServiceTest.cls
+++ b/force-app/main/default/classes/ElaroGLBAPrivacyNoticeServiceTest.cls
@@ -94,7 +94,7 @@ private class ElaroGLBAPrivacyNoticeServiceTest {
         Test.stopTest();
         
         // Then: Annual notices should be created
-        System.assert(!notices.isEmpty(), 'Should create annual notices');
+        Assert.isTrue(!notices.isEmpty(), 'Should create annual notices');
         for (Privacy_Notice__c notice : notices) {
             Assert.areEqual('Annual', notice.Notice_Type__c, 'Should be annual notice');
             Assert.areEqual('Pending', notice.Delivery_Status__c, 'Status should be Pending');
@@ -167,7 +167,7 @@ private class ElaroGLBAPrivacyNoticeServiceTest {
             } catch (Exception e) {
                 // Then: Permission exception should be thrown
                 // Note: InsufficientAccessException may not be available, catch generic Exception
-                System.assert(e.getMessage().contains('insufficient') || 
+                Assert.isTrue(e.getMessage().contains('insufficient') || 
                     e.getMessage().contains('access') || 
                     e.getMessage().contains('permission'), 
                     'Should throw permission-related exception: ' + e.getMessage());
@@ -186,7 +186,7 @@ private class ElaroGLBAPrivacyNoticeServiceTest {
         
         // Then: Metrics should be returned
         Assert.areNotEqual(null, metrics, 'Metrics should be returned');
-        System.assert(metrics.containsKey('totalNoticesThisYear'), 'Should have total notices metric');
+        Assert.isTrue(metrics.containsKey('totalNoticesThisYear'), 'Should have total notices metric');
     }
     
     @IsTest
@@ -227,7 +227,7 @@ private class ElaroGLBAPrivacyNoticeServiceTest {
         Test.stopTest();
         
         // Then: Should process bulk contacts
-        System.assert(annualNotices.size() >= 200, 'Should create annual notices for bulk contacts');
+        Assert.isTrue(annualNotices.size() >= 200, 'Should create annual notices for bulk contacts');
     }
     
     // Helper method to create limited user for permission testing

--- a/force-app/main/default/classes/ElaroGraphIndexerTest.cls
+++ b/force-app/main/default/classes/ElaroGraphIndexerTest.cls
@@ -51,7 +51,7 @@ private class ElaroGraphIndexerTest {
             ElaroGraphIndexer.indexChange('PERMISSION_SET', ps.Id, null, 'INVALID_FRAMEWORK');
             Assert.fail( 'Should have thrown exception for invalid framework');
         } catch (Exception e) {
-            System.assert(e.getMessage().contains('Unsupported framework'), 'Expected framework validation error');
+            Assert.isTrue(e.getMessage().contains('Unsupported framework'), 'Expected framework validation error');
         }
         Test.stopTest();
     }
@@ -141,7 +141,7 @@ private class ElaroGraphIndexerTest {
                 ElaroGraphIndexer.indexChange('FLOW', 'NonExistentFlowId', null, 'SOC2');
                 Assert.fail( 'Should have thrown exception for non-existent flow');
             } catch (Exception e) {
-                System.assert(e.getMessage().contains('FlowDefinitionView not found') || 
+                Assert.isTrue(e.getMessage().contains('FlowDefinitionView not found') || 
                              e.getMessage().contains('failed'), 
                              'Expected flow not found error: ' + e.getMessage());
             }
@@ -201,7 +201,7 @@ private class ElaroGraphIndexerTest {
             'POLICY_VIOLATION', 'UNAUTHORIZED', 'ANOMALY', 'MANUAL_OVERRIDE'
         };
         for (Elaro_Compliance_Graph__b node : nodes) {
-            System.assert(validCategories.contains(node.Drift_Category__c), 
+            Assert.isTrue(validCategories.contains(node.Drift_Category__c), 
                          'Node should have valid drift category: ' + node.Drift_Category__c);
             Assert.areNotEqual(null, node.Risk_Score__c, 'Risk score should not be null');
         }
@@ -235,9 +235,9 @@ private class ElaroGraphIndexerTest {
         
         // Fallback risk score should be BASE_RISK_SCORE (3.0) or higher
         // Since objectPermissionCount is added, score should be at least 3.0
-        System.assert(nodes[0].Risk_Score__c >= 3.0, 
+        Assert.isTrue(nodes[0].Risk_Score__c >= 3.0, 
                      'Fallback risk score should be at least BASE_RISK_SCORE (3.0), got: ' + nodes[0].Risk_Score__c);
-        System.assert(nodes[0].Risk_Score__c <= 10.0, 
+        Assert.isTrue(nodes[0].Risk_Score__c <= 10.0, 
                      'Risk score should not exceed RISK_SCORE_MAX (10.0), got: ' + nodes[0].Risk_Score__c);
     }
 }

--- a/force-app/main/default/classes/ElaroHIPAAComplianceServiceTest.cls
+++ b/force-app/main/default/classes/ElaroHIPAAComplianceServiceTest.cls
@@ -29,8 +29,8 @@ private class ElaroHIPAAComplianceServiceTest {
         
         // Then: Should calculate risk score
         Assert.areNotEqual(null, score, 'Risk score should not be null');
-        System.assert(score >= 0 && score <= 10, 'Risk score should be between 0 and 10');
-        System.assert(score > 3.0, 'High permission count should increase risk score');
+        Assert.isTrue(score >= 0 && score <= 10, 'Risk score should be between 0 and 10');
+        Assert.isTrue(score > 3.0, 'High permission count should increase risk score');
     }
     
     @IsTest
@@ -46,7 +46,7 @@ private class ElaroHIPAAComplianceServiceTest {
         Test.stopTest();
         
         // Then: Should have lower risk score
-        System.assert(score <= 5.0, 'Low permission count should result in lower risk');
+        Assert.isTrue(score <= 5.0, 'Low permission count should result in lower risk');
     }
     
     @IsTest

--- a/force-app/main/default/classes/ElaroHistoricalEventBatchTest.cls
+++ b/force-app/main/default/classes/ElaroHistoricalEventBatchTest.cls
@@ -71,7 +71,7 @@ private class ElaroHistoricalEventBatchTest {
             AND Status = 'Completed'
         ];
         
-        System.assert(jobs.size() &gt; 0, 'Batches should complete');
+        Assert.isTrue(jobs.size() &gt; 0, 'Batches should complete');
     }
     
     @isTest

--- a/force-app/main/default/classes/ElaroISO27001AccessReviewServiceTest.cls
+++ b/force-app/main/default/classes/ElaroISO27001AccessReviewServiceTest.cls
@@ -79,7 +79,7 @@ private class ElaroISO27001AccessReviewServiceTest {
         Test.stopTest();
         
         // Then: Reviews should be created
-        System.assert(!reviews.isEmpty(), 'Should create reviews');
+        Assert.isTrue(!reviews.isEmpty(), 'Should create reviews');
         for (Access_Review__c review : reviews) {
             Assert.areEqual('Quarterly Review', review.Review_Type__c, 'Should be quarterly review');
             Assert.areEqual('Pending', review.Review_Status__c, 'Status should be Pending');
@@ -98,7 +98,7 @@ private class ElaroISO27001AccessReviewServiceTest {
         Test.stopTest();
         
         // Then: Privileged reviews should be created
-        System.assert(!reviews.isEmpty(), 'Should create privileged reviews');
+        Assert.isTrue(!reviews.isEmpty(), 'Should create privileged reviews');
         for (Access_Review__c review : reviews) {
             Assert.areEqual('Privileged Access Review', review.Review_Type__c, 
                 'Should be privileged review');
@@ -171,7 +171,7 @@ private class ElaroISO27001AccessReviewServiceTest {
             } catch (Exception e) {
                 // Then: Permission exception should be thrown
                 // Note: InsufficientAccessException may not be available, catch generic Exception
-                System.assert(e.getMessage().contains('insufficient') || 
+                Assert.isTrue(e.getMessage().contains('insufficient') || 
                     e.getMessage().contains('access') || 
                     e.getMessage().contains('permission'), 
                     'Should throw permission-related exception: ' + e.getMessage());
@@ -193,9 +193,9 @@ private class ElaroISO27001AccessReviewServiceTest {
         Test.stopTest();
         
         // Then: Should return pending reviews for reviewer
-        System.assert(pendingReviews.size() >= 0, 'Should return pending reviews');
+        Assert.isTrue(pendingReviews.size() >= 0, 'Should return pending reviews');
         for (Access_Review__c review : pendingReviews) {
-            System.assert(review.Review_Status__c == 'Pending' || review.Review_Status__c == 'In Progress', 
+            Assert.isTrue(review.Review_Status__c == 'Pending' || review.Review_Status__c == 'In Progress', 
                 'Should only return pending/in progress reviews');
             Assert.areEqual(manager.Id, review.Reviewer__c, 'Should match reviewer');
         }
@@ -219,9 +219,9 @@ private class ElaroISO27001AccessReviewServiceTest {
         Test.stopTest();
         
         // Then: Should return overdue reviews
-        System.assert(overdueReviews.size() >= 0, 'Should return overdue reviews');
+        Assert.isTrue(overdueReviews.size() >= 0, 'Should return overdue reviews');
         for (Access_Review__c review : overdueReviews) {
-            System.assert(review.Due_Date__c < Date.today(), 'Should be overdue');
+            Assert.isTrue(review.Due_Date__c < Date.today(), 'Should be overdue');
         }
     }
     
@@ -235,7 +235,7 @@ private class ElaroISO27001AccessReviewServiceTest {
         Test.stopTest();
         
         // Then: Should handle bulk users
-        System.assert(reviews.size() >= 0, 'Should process users');
+        Assert.isTrue(reviews.size() >= 0, 'Should process users');
         // Note: Actual count depends on org setup
     }
     
@@ -311,11 +311,11 @@ private class ElaroISO27001AccessReviewServiceTest {
 
         // Then: Should return metrics
         Assert.areNotEqual(null, metrics, 'Metrics should not be null');
-        System.assert(metrics.containsKey('reviewsThisQuarter'), 'Should have reviewsThisQuarter metric');
-        System.assert(metrics.containsKey('completionRate'), 'Should have completionRate metric');
-        System.assert(metrics.containsKey('overdueCount'), 'Should have overdueCount metric');
-        System.assert(metrics.containsKey('privilegedUsersCount'), 'Should have privilegedUsersCount metric');
-        System.assert(metrics.containsKey('dormantAccountsCount'), 'Should have dormantAccountsCount metric');
+        Assert.isTrue(metrics.containsKey('reviewsThisQuarter'), 'Should have reviewsThisQuarter metric');
+        Assert.isTrue(metrics.containsKey('completionRate'), 'Should have completionRate metric');
+        Assert.isTrue(metrics.containsKey('overdueCount'), 'Should have overdueCount metric');
+        Assert.isTrue(metrics.containsKey('privilegedUsersCount'), 'Should have privilegedUsersCount metric');
+        Assert.isTrue(metrics.containsKey('dormantAccountsCount'), 'Should have dormantAccountsCount metric');
     }
 
     @IsTest
@@ -425,7 +425,7 @@ private class ElaroISO27001AccessReviewServiceTest {
         for (Access_Review__c review : reviews) {
             if (review.Risk_Level__c != null) {
                 hasRiskLevel = true;
-                System.assert(
+                Assert.isTrue(
                     review.Risk_Level__c == 'Low' ||
                     review.Risk_Level__c == 'Medium' ||
                     review.Risk_Level__c == 'High' ||
@@ -434,7 +434,7 @@ private class ElaroISO27001AccessReviewServiceTest {
                 );
             }
         }
-        System.assert(hasRiskLevel, 'At least one review should have risk level set');
+        Assert.isTrue(hasRiskLevel, 'At least one review should have risk level set');
     }
 
     @IsTest

--- a/force-app/main/default/classes/ElaroInstallHandlerTest.cls
+++ b/force-app/main/default/classes/ElaroInstallHandlerTest.cls
@@ -133,7 +133,7 @@ private class ElaroInstallHandlerTest {
         ];
         Assert.areEqual(1, auditLogs.size(), 'Should create upgrade audit log');
         Assert.areEqual('Upgrade', auditLogs[0].Event_Type__c, 'Should log as upgrade');
-        System.assert(auditLogs[0].Description__c.contains('2.5'), 'Should reference previous version');
+        Assert.isTrue(auditLogs[0].Description__c.contains('2.5'), 'Should reference previous version');
     }
 
     /**
@@ -235,10 +235,10 @@ private class ElaroInstallHandlerTest {
 
         // Assert
         Assert.areNotEqual(null, summary, 'Summary should not be null');
-        System.assert(summary.contains('Elaro Installation Summary'), 'Should contain header');
-        System.assert(summary.contains('Type: New Installation'), 'Should contain installation type');
-        System.assert(summary.contains('Org ID: ' + UserInfo.getOrganizationId()), 'Should contain org ID');
-        System.assert(summary.contains('Installer ID: ' + UserInfo.getUserId()), 'Should contain installer ID');
+        Assert.isTrue(summary.contains('Elaro Installation Summary'), 'Should contain header');
+        Assert.isTrue(summary.contains('Type: New Installation'), 'Should contain installation type');
+        Assert.isTrue(summary.contains('Org ID: ' + UserInfo.getOrganizationId()), 'Should contain org ID');
+        Assert.isTrue(summary.contains('Installer ID: ' + UserInfo.getUserId()), 'Should contain installer ID');
     }
 
     /**
@@ -256,8 +256,8 @@ private class ElaroInstallHandlerTest {
         Test.stopTest();
 
         // Assert
-        System.assert(summary.contains('Type: Upgrade'), 'Should contain upgrade type');
-        System.assert(summary.contains('Previous Version: 2.5'), 'Should contain previous version');
+        Assert.isTrue(summary.contains('Type: Upgrade'), 'Should contain upgrade type');
+        Assert.isTrue(summary.contains('Previous Version: 2.5'), 'Should contain previous version');
     }
 
     /**
@@ -333,7 +333,7 @@ private class ElaroInstallHandlerTest {
             SELECT Id FROM Elaro_Audit_Log__c
             WHERE Action__c = 'Package Installation'
         ];
-        System.assert(auditLogs.size() >= 1, 'Should have at least one audit log');
+        Assert.isTrue(auditLogs.size() >= 1, 'Should have at least one audit log');
     }
 
     /**

--- a/force-app/main/default/classes/ElaroIntegrationTest.cls
+++ b/force-app/main/default/classes/ElaroIntegrationTest.cls
@@ -63,7 +63,7 @@ private class ElaroIntegrationTest {
         
         // Verify alerts were created
         Assert.areEqual(true, result.warning, 'Should trigger warning');
-        System.assert(result.eventsPublished > 0, 'Should have published alerts');
+        Assert.isTrue(result.eventsPublished > 0, 'Should have published alerts');
         
         // Verify Performance_Alert_History__c records were created
         List<Performance_Alert_History__c> alerts = [
@@ -71,7 +71,7 @@ private class ElaroIntegrationTest {
             FROM Performance_Alert_History__c
             WHERE Context_Record__c = 'integrationTest'
         ];
-        System.assert(alerts.size() >= 4, 'Should have created at least 4 alert records');
+        Assert.isTrue(alerts.size() >= 4, 'Should have created at least 4 alert records');
     }
     
     /**
@@ -101,7 +101,7 @@ private class ElaroIntegrationTest {
         
         // Verify score calculation succeeded
         Assert.areNotEqual(null, scoreResult, 'Score result should not be null');
-        System.assert(scoreResult.overallScore >= 0 && scoreResult.overallScore <= 100, 
+        Assert.isTrue(scoreResult.overallScore >= 0 && scoreResult.overallScore <= 100, 
                      'Score should be between 0 and 100');
     }
     
@@ -141,7 +141,7 @@ private class ElaroIntegrationTest {
             FROM Elaro_Compliance_Graph__b
             WHERE Entity_Record_Id__c = :ps.Id
         ];
-        System.assert(nodes.size() >= 2, 'Should have created nodes for both frameworks');
+        Assert.isTrue(nodes.size() >= 2, 'Should have created nodes for both frameworks');
         
         // Verify score calculation reflects settings
         Assert.areNotEqual(null, scoreResult, 'Score result should not be null');

--- a/force-app/main/default/classes/ElaroLegalDocumentGeneratorTest.cls
+++ b/force-app/main/default/classes/ElaroLegalDocumentGeneratorTest.cls
@@ -17,8 +17,8 @@ private class ElaroLegalDocumentGeneratorTest {
 
         List<ContentDocument> docs = [SELECT Id, Title FROM ContentDocument WHERE Id = :contentDocId];
         Assert.areEqual(1, docs.size(), 'Should create one ContentDocument');
-        System.assert(docs[0].Title.contains('SOC2'), 'Document title should contain framework name');
-        System.assert(docs[0].Title.contains('Evidence_Pack'), 'Document title should contain Evidence_Pack');
+        Assert.isTrue(docs[0].Title.contains('SOC2'), 'Document title should contain framework name');
+        Assert.isTrue(docs[0].Title.contains('Evidence_Pack'), 'Document title should contain Evidence_Pack');
     }
 
     @IsTest
@@ -35,7 +35,7 @@ private class ElaroLegalDocumentGeneratorTest {
         // Then: Should create document with GDPR in title
         List<ContentDocument> docs = [SELECT Id, Title FROM ContentDocument WHERE Id = :contentDocId];
         Assert.areEqual(1, docs.size(), 'Should create one ContentDocument');
-        System.assert(docs[0].Title.contains('GDPR'), 'Document title should contain GDPR');
+        Assert.isTrue(docs[0].Title.contains('GDPR'), 'Document title should contain GDPR');
     }
 
     @IsTest
@@ -51,7 +51,7 @@ private class ElaroLegalDocumentGeneratorTest {
 
         // Then: Should create document with HIPAA in title
         List<ContentDocument> docs = [SELECT Id, Title FROM ContentDocument WHERE Id = :contentDocId];
-        System.assert(docs[0].Title.contains('HIPAA'), 'Document title should contain HIPAA');
+        Assert.isTrue(docs[0].Title.contains('HIPAA'), 'Document title should contain HIPAA');
     }
 
     @IsTest
@@ -73,7 +73,7 @@ private class ElaroLegalDocumentGeneratorTest {
         ];
         Assert.areEqual(1, versions.size(), 'Should have one version');
         Assert.areEqual(true, versions[0].IsMajorVersion, 'Should be a major version');
-        System.assert(versions[0].PathOnClient.endsWith('.txt'), 'File should be .txt');
+        Assert.isTrue(versions[0].PathOnClient.endsWith('.txt'), 'File should be .txt');
     }
 
     @IsTest
@@ -95,10 +95,10 @@ private class ElaroLegalDocumentGeneratorTest {
             LIMIT 1
         ];
         String content = cv.VersionData.toString();
-        System.assert(content.contains('COMPLIANCE EVIDENCE PACK'), 'Should contain header');
-        System.assert(content.contains('Framework: SOC2'), 'Should contain framework');
-        System.assert(content.contains('Total Events:'), 'Should contain event count');
-        System.assert(content.contains('DETAILED AUDIT LOG'), 'Should contain audit log section');
+        Assert.isTrue(content.contains('COMPLIANCE EVIDENCE PACK'), 'Should contain header');
+        Assert.isTrue(content.contains('Framework: SOC2'), 'Should contain framework');
+        Assert.isTrue(content.contains('Total Events:'), 'Should contain event count');
+        Assert.isTrue(content.contains('DETAILED AUDIT LOG'), 'Should contain audit log section');
     }
 
     @IsTest
@@ -135,7 +135,7 @@ private class ElaroLegalDocumentGeneratorTest {
             LIMIT 1
         ];
         String content = cv.VersionData.toString();
-        System.assert(content.contains('Total Events: 0'), 'Should show zero events when no data');
+        Assert.isTrue(content.contains('Total Events: 0'), 'Should show zero events when no data');
     }
 
     @IsTest
@@ -163,7 +163,7 @@ private class ElaroLegalDocumentGeneratorTest {
                 // May succeed if user has implicit permissions
             } catch (AuraHandledException e) {
                 // Expected: Should throw AuraHandledException for permission issues
-                System.assert(e.getMessage().contains('Error generating evidence pack'),
+                Assert.isTrue(e.getMessage().contains('Error generating evidence pack'),
                     'Should throw appropriate error message');
             }
         }
@@ -181,7 +181,7 @@ private class ElaroLegalDocumentGeneratorTest {
             ElaroLegalDocumentGenerator.generateLegalAttestation(null, startDate, endDate);
             Assert.fail( 'Should have thrown exception for null framework');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Framework cannot be blank'),
+            Assert.isTrue(e.getMessage().contains('Framework cannot be blank'),
                 'Should throw validation error for null framework');
         }
         Test.stopTest();
@@ -198,7 +198,7 @@ private class ElaroLegalDocumentGeneratorTest {
             ElaroLegalDocumentGenerator.generateLegalAttestation('', startDate, endDate);
             Assert.fail( 'Should have thrown exception for blank framework');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Framework cannot be blank'),
+            Assert.isTrue(e.getMessage().contains('Framework cannot be blank'),
                 'Should throw validation error for blank framework');
         }
         Test.stopTest();
@@ -215,7 +215,7 @@ private class ElaroLegalDocumentGeneratorTest {
             ElaroLegalDocumentGenerator.generateLegalAttestation('INVALID_FRAMEWORK', startDate, endDate);
             Assert.fail( 'Should have thrown exception for invalid framework');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Unsupported framework'),
+            Assert.isTrue(e.getMessage().contains('Unsupported framework'),
                 'Should throw validation error for invalid framework');
         }
         Test.stopTest();
@@ -229,7 +229,7 @@ private class ElaroLegalDocumentGeneratorTest {
             ElaroLegalDocumentGenerator.generateLegalAttestation('SOC2', null, Date.today());
             Assert.fail( 'Should have thrown exception for null start date');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Start date cannot be null'),
+            Assert.isTrue(e.getMessage().contains('Start date cannot be null'),
                 'Should throw validation error for null start date');
         }
         Test.stopTest();
@@ -243,7 +243,7 @@ private class ElaroLegalDocumentGeneratorTest {
             ElaroLegalDocumentGenerator.generateLegalAttestation('SOC2', Date.today(), null);
             Assert.fail( 'Should have thrown exception for null end date');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('End date cannot be null'),
+            Assert.isTrue(e.getMessage().contains('End date cannot be null'),
                 'Should throw validation error for null end date');
         }
         Test.stopTest();
@@ -257,7 +257,7 @@ private class ElaroLegalDocumentGeneratorTest {
             ElaroLegalDocumentGenerator.generateLegalAttestation('SOC2', Date.today(), Date.today().addDays(-30));
             Assert.fail( 'Should have thrown exception for invalid date range');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Start date cannot be after end date'),
+            Assert.isTrue(e.getMessage().contains('Start date cannot be after end date'),
                 'Should throw validation error for invalid date range');
         }
         Test.stopTest();

--- a/force-app/main/default/classes/ElaroLoggerTest.cls
+++ b/force-app/main/default/classes/ElaroLoggerTest.cls
@@ -112,6 +112,6 @@ private class ElaroLoggerTest {
         Test.stopTest();
 
         // No exceptions should be thrown
-        System.assert(Test.isRunningTest(), 'Running in test context');
+        Assert.isTrue(Test.isRunningTest(), 'Running in test context');
     }
 }

--- a/force-app/main/default/classes/ElaroMatrixControllerTest.cls
+++ b/force-app/main/default/classes/ElaroMatrixControllerTest.cls
@@ -74,7 +74,7 @@ private class ElaroMatrixControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for empty config');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for empty config');
     }
 
     @isTest
@@ -87,7 +87,7 @@ private class ElaroMatrixControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for null config');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for null config');
     }
 
     @isTest
@@ -100,7 +100,7 @@ private class ElaroMatrixControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for invalid JSON');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for invalid JSON');
     }
 
     @isTest
@@ -121,7 +121,7 @@ private class ElaroMatrixControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for invalid object');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for invalid object');
     }
 
     @isTest
@@ -142,7 +142,7 @@ private class ElaroMatrixControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for missing row field');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for missing row field');
     }
 
     @isTest
@@ -163,7 +163,7 @@ private class ElaroMatrixControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for missing column field');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for missing column field');
     }
 
     @isTest
@@ -184,7 +184,7 @@ private class ElaroMatrixControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for missing aggregate');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for missing aggregate');
     }
 
     @isTest
@@ -205,7 +205,7 @@ private class ElaroMatrixControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for invalid aggregate');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for invalid aggregate');
     }
 
     @isTest
@@ -226,7 +226,7 @@ private class ElaroMatrixControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for invalid field');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for invalid field');
     }
 
     @isTest
@@ -247,7 +247,7 @@ private class ElaroMatrixControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for non-groupable field');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for non-groupable field');
     }
 
     @isTest
@@ -356,7 +356,7 @@ private class ElaroMatrixControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for dangerous filter');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for dangerous filter');
     }
 
     @isTest
@@ -379,7 +379,7 @@ private class ElaroMatrixControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for invalid object');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for invalid object');
     }
 
     @isTest
@@ -392,7 +392,7 @@ private class ElaroMatrixControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for null object');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for null object');
     }
 
     @isTest

--- a/force-app/main/default/classes/ElaroPCIAccessLoggerTest.cls
+++ b/force-app/main/default/classes/ElaroPCIAccessLoggerTest.cls
@@ -32,7 +32,7 @@ private class ElaroPCIAccessLoggerTest {
 
         // Verify platform event was published successfully
         // Platform events use DML operations
-        System.assert(Limits.getDmlStatements() > 0, 'Should publish platform event via DML');
+        Assert.isTrue(Limits.getDmlStatements() > 0, 'Should publish platform event via DML');
     }
 
     @IsTest
@@ -54,7 +54,7 @@ private class ElaroPCIAccessLoggerTest {
 
         // Verify all access types were logged via platform events
         Assert.areEqual(5, accessTypes.size(), 'Should test all 5 access types');
-        System.assert(Limits.getDmlStatements() >= accessTypes.size(), 'Should publish event for each access type');
+        Assert.isTrue(Limits.getDmlStatements() >= accessTypes.size(), 'Should publish event for each access type');
     }
 
     @IsTest
@@ -75,7 +75,7 @@ private class ElaroPCIAccessLoggerTest {
 
         // Verify bulk logging completed with proper bulkification
         Assert.areEqual(200, recordIds.size(), 'Should process 200 records');
-        System.assert(Limits.getDmlStatements() <= 2, 'Should bulkify platform event publishing');
+        Assert.isTrue(Limits.getDmlStatements() <= 2, 'Should bulkify platform event publishing');
     }
 
     @IsTest
@@ -107,7 +107,7 @@ private class ElaroPCIAccessLoggerTest {
         Test.stopTest();
 
         // Verify failed access event was published
-        System.assert(Limits.getDmlStatements() > 0, 'Should publish failed access event');
+        Assert.isTrue(Limits.getDmlStatements() > 0, 'Should publish failed access event');
     }
 
     @IsTest
@@ -123,7 +123,7 @@ private class ElaroPCIAccessLoggerTest {
 
         // Verify sensitive data view event was published
         Assert.areEqual(3, dataElements.size(), 'Should track 3 data elements');
-        System.assert(Limits.getDmlStatements() > 0, 'Should publish sensitive data view event');
+        Assert.isTrue(Limits.getDmlStatements() > 0, 'Should publish sensitive data view event');
     }
 
     @IsTest
@@ -188,7 +188,7 @@ private class ElaroPCIAccessLoggerTest {
         Test.stopTest();
 
         // Platform event publish is a single DML
-        System.assert(endDML - startDML <= 2, 'Should be bulkified');
+        Assert.isTrue(endDML - startDML <= 2, 'Should be bulkified');
     }
 
     @IsTest
@@ -218,7 +218,7 @@ private class ElaroPCIAccessLoggerTest {
 
         // Verify concurrent logging completed successfully
         Assert.areEqual(10, accounts.size(), 'Should process 10 accounts');
-        System.assert(Limits.getDmlStatements() >= 20, 'Should publish 20 events (2 per account)');
+        Assert.isTrue(Limits.getDmlStatements() >= 20, 'Should publish 20 events (2 per account)');
     }
 
     @IsTest
@@ -236,6 +236,6 @@ private class ElaroPCIAccessLoggerTest {
 
         // Verify method handles missing session info gracefully in test context
         // Should still publish event even if session details are unavailable
-        System.assert(Limits.getDmlStatements() > 0, 'Should publish event despite missing session info');
+        Assert.isTrue(Limits.getDmlStatements() > 0, 'Should publish event despite missing session info');
     }
 }

--- a/force-app/main/default/classes/ElaroPCIDSSComplianceServiceTest.cls
+++ b/force-app/main/default/classes/ElaroPCIDSSComplianceServiceTest.cls
@@ -18,8 +18,8 @@ private class ElaroPCIDSSComplianceServiceTest {
         
         // Then: Should calculate risk score
         Assert.areNotEqual(null, score, 'Risk score should not be null');
-        System.assert(score >= 0 && score <= 10, 'Risk score should be between 0 and 10');
-        System.assert(score > 3.0, 'Cardholder data fields should have higher risk');
+        Assert.isTrue(score >= 0 && score <= 10, 'Risk score should be between 0 and 10');
+        Assert.isTrue(score > 3.0, 'Cardholder data fields should have higher risk');
     }
     
     @IsTest

--- a/force-app/main/default/classes/ElaroPCIDataMaskingServiceTest.cls
+++ b/force-app/main/default/classes/ElaroPCIDataMaskingServiceTest.cls
@@ -93,7 +93,7 @@ private class ElaroPCIDataMaskingServiceTest {
             ElaroPCIDataMaskingService.validateNoCVVStorage('123');
             Assert.fail( 'Should throw PCIViolationException');
         } catch (ElaroPCIDataMaskingService.PCIViolationException e) {
-            System.assert(e.getMessage().contains('PCI DSS Requirement 3.2'),
+            Assert.isTrue(e.getMessage().contains('PCI DSS Requirement 3.2'),
                 'Should mention PCI requirement');
         }
         Test.stopTest();
@@ -239,7 +239,7 @@ private class ElaroPCIDataMaskingServiceTest {
 
         Assert.areEqual(200, maskedCards.size(), 'Should mask all 200 cards');
         for (String masked : maskedCards) {
-            System.assert(masked.startsWith('****-****-****-'), 'All should be properly masked');
+            Assert.isTrue(masked.startsWith('****-****-****-'), 'All should be properly masked');
         }
     }
 
@@ -252,7 +252,7 @@ private class ElaroPCIDataMaskingServiceTest {
             Assert.isTrue(true, 'Encryption validation passed');
         } catch (ElaroPCIDataMaskingService.PCIViolationException e) {
             // This may throw in environments without Shield
-            System.assert(e.getMessage().contains('Platform Encryption'),
+            Assert.isTrue(e.getMessage().contains('Platform Encryption'),
                 'Should mention encryption requirement');
         }
         Test.stopTest();

--- a/force-app/main/default/classes/ElaroPDFControllerTest.cls
+++ b/force-app/main/default/classes/ElaroPDFControllerTest.cls
@@ -61,7 +61,7 @@ private class ElaroPDFControllerTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, controller.auditPackage, 'Audit package should be loaded');
-        System.assert(controller.evidenceCount > 0, 'Evidence should be loaded');
+        Assert.isTrue(controller.evidenceCount > 0, 'Evidence should be loaded');
         Assert.areNotEqual(null, controller.generatedAt, 'Generated timestamp should be set');
         Assert.areNotEqual(null, controller.documentHash, 'Document hash should be generated');
     }
@@ -91,7 +91,7 @@ private class ElaroPDFControllerTest {
         Decimal score = controller.getComplianceScore();
         Test.stopTest();
 
-        System.assert(score >= 0 && score <= 100, 'Score should be between 0 and 100');
+        Assert.isTrue(score >= 0 && score <= 100, 'Score should be between 0 and 100');
     }
 
     @isTest
@@ -104,7 +104,7 @@ private class ElaroPDFControllerTest {
         String dateRange = controller.getDateRange();
         Test.stopTest();
 
-        System.assert(dateRange.contains(' - '), 'Date range should contain separator');
+        Assert.isTrue(dateRange.contains(' - '), 'Date range should contain separator');
     }
 
     @isTest
@@ -131,7 +131,7 @@ private class ElaroPDFControllerTest {
         ElaroPDFController controller = new ElaroPDFController(stdController);
         Test.stopTest();
 
-        System.assert(controller.controlSummary.size() > 0, 'Control summary should be populated');
+        Assert.isTrue(controller.controlSummary.size() > 0, 'Control summary should be populated');
     }
 
     @isTest

--- a/force-app/main/default/classes/ElaroPDFExporterTest.cls
+++ b/force-app/main/default/classes/ElaroPDFExporterTest.cls
@@ -27,7 +27,7 @@ private class ElaroPDFExporterTest {
         Assert.areNotEqual(null, contentVersionId, 'Should return ContentVersion ID');
         
         ContentVersion cv = [SELECT Title, FileExtension FROM ContentVersion WHERE Id = :contentVersionId];
-        System.assert(cv.Title.contains('Audit Package'), 'Title should contain Audit Package');
+        Assert.isTrue(cv.Title.contains('Audit Package'), 'Title should contain Audit Package');
         Assert.areEqual('pdf', cv.FileExtension, 'Should be PDF file');
     }
     
@@ -51,7 +51,7 @@ private class ElaroPDFExporterTest {
             ElaroPDFExporter.generateAuditPackagePDF(null);
             Assert.fail( 'Should throw exception');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should mention required');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should mention required');
         }
         Test.stopTest();
     }
@@ -83,7 +83,7 @@ private class ElaroPDFExporterTest {
         Assert.areNotEqual(null, contentVersionId, 'Should return ContentVersion ID');
         
         ContentVersion cv = [SELECT Title FROM ContentVersion WHERE Id = :contentVersionId];
-        System.assert(cv.Title.contains('Executive Summary'), 'Title should contain Executive Summary');
+        Assert.isTrue(cv.Title.contains('Executive Summary'), 'Title should contain Executive Summary');
     }
     
     // ═══════════════════════════════════════════════════════════════
@@ -102,7 +102,7 @@ private class ElaroPDFExporterTest {
         Assert.areNotEqual(null, contentVersionId, 'Should return ContentVersion ID');
         
         ContentVersion cv = [SELECT Title FROM ContentVersion WHERE Id = :contentVersionId];
-        System.assert(cv.Title.contains('Evidence Report'), 'Title should contain Evidence Report');
+        Assert.isTrue(cv.Title.contains('Evidence Report'), 'Title should contain Evidence Report');
     }
     
     @isTest
@@ -129,8 +129,8 @@ private class ElaroPDFExporterTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, csvContent, 'Should return CSV content');
-        System.assert(csvContent.contains('Evidence ID'), 'Should contain header row');
-        System.assert(csvContent.contains(','), 'Should be comma-separated');
+        Assert.isTrue(csvContent.contains('Evidence ID'), 'Should contain header row');
+        Assert.isTrue(csvContent.contains(','), 'Should be comma-separated');
     }
     
     @isTest
@@ -177,9 +177,9 @@ private class ElaroPDFExporterTest {
         
         // Verify it's valid JSON
         Map&lt;String, Object&gt; parsed = (Map&lt;String, Object&gt;)JSON.deserializeUntyped(jsonContent);
-        System.assert(parsed.containsKey('package'), 'Should contain package data');
-        System.assert(parsed.containsKey('evidence'), 'Should contain evidence data');
-        System.assert(parsed.containsKey('exportDate'), 'Should contain export date');
+        Assert.isTrue(parsed.containsKey('package'), 'Should contain package data');
+        Assert.isTrue(parsed.containsKey('evidence'), 'Should contain evidence data');
+        Assert.isTrue(parsed.containsKey('exportDate'), 'Should contain export date');
     }
     
     @isTest
@@ -191,10 +191,10 @@ private class ElaroPDFExporterTest {
         Test.stopTest();
         
         Map&lt;String, Object&gt; parsed = (Map&lt;String, Object&gt;)JSON.deserializeUntyped(jsonContent);
-        System.assert(parsed.containsKey('metadata'), 'Should contain metadata');
+        Assert.isTrue(parsed.containsKey('metadata'), 'Should contain metadata');
         
         Map&lt;String, Object&gt; metadata = (Map&lt;String, Object&gt;)parsed.get('metadata');
-        System.assert(metadata.containsKey('generatedBy'), 'Should contain generatedBy');
+        Assert.isTrue(metadata.containsKey('generatedBy'), 'Should contain generatedBy');
     }
     
     // ═══════════════════════════════════════════════════════════════

--- a/force-app/main/default/classes/ElaroRealtimeMonitorTest.cls
+++ b/force-app/main/default/classes/ElaroRealtimeMonitorTest.cls
@@ -18,8 +18,8 @@ private class ElaroRealtimeMonitorTest {
         Test.stopTest();
         
         // Login base score is 20, may have additional factors
-        System.assert(riskScore &gt;= 20, 'Login event should have minimum score of 20');
-        System.assert(riskScore &lt;= 100, 'Score should not exceed 100');
+        Assert.isTrue(riskScore &gt;= 20, 'Login event should have minimum score of 20');
+        Assert.isTrue(riskScore &lt;= 100, 'Score should not exceed 100');
     }
     
     @isTest
@@ -31,7 +31,7 @@ private class ElaroRealtimeMonitorTest {
         Test.stopTest();
         
         // LoginAs base score is 70
-        System.assert(riskScore &gt;= 70, 'LoginAs event should have minimum score of 70');
+        Assert.isTrue(riskScore &gt;= 70, 'LoginAs event should have minimum score of 70');
     }
     
     @isTest
@@ -44,7 +44,7 @@ private class ElaroRealtimeMonitorTest {
         Test.stopTest();
         
         // API base (40) + volume factor (20 for &gt;10000 rows)
-        System.assert(riskScore &gt;= 60, 'High volume should add 20 to score');
+        Assert.isTrue(riskScore &gt;= 60, 'High volume should add 20 to score');
     }
     
     @isTest
@@ -57,7 +57,7 @@ private class ElaroRealtimeMonitorTest {
         Test.stopTest();
         
         // Login base (20) + location factor (15)
-        System.assert(riskScore &gt;= 35, 'Non-US location should add 15 to score');
+        Assert.isTrue(riskScore &gt;= 35, 'Non-US location should add 15 to score');
     }
     
     @isTest
@@ -70,7 +70,7 @@ private class ElaroRealtimeMonitorTest {
         Integer riskScore = ElaroRealtimeMonitor.calculateRiskScore(eventData);
         Test.stopTest();
         
-        System.assert(riskScore &gt;= 35, 'Non-US geo location should add 15 to score');
+        Assert.isTrue(riskScore &gt;= 35, 'Non-US geo location should add 15 to score');
     }
     
     @isTest
@@ -87,7 +87,7 @@ private class ElaroRealtimeMonitorTest {
         Integer riskScore = ElaroRealtimeMonitor.calculateRiskScore(eventData);
         Test.stopTest();
         
-        System.assert(riskScore &lt;= 100, 'Score should be capped at 100');
+        Assert.isTrue(riskScore &lt;= 100, 'Score should be capped at 100');
     }
     
     @isTest
@@ -108,7 +108,7 @@ private class ElaroRealtimeMonitorTest {
         Test.stopTest();
         
         // Unknown event type defaults to 10
-        System.assert(riskScore &gt;= 0, 'Empty event should return base score');
+        Assert.isTrue(riskScore &gt;= 0, 'Empty event should return base score');
     }
     
     @isTest
@@ -123,7 +123,7 @@ private class ElaroRealtimeMonitorTest {
         Test.stopTest();
         
         // API base (40) + volume factor (10 for &gt;1000 rows)
-        System.assert(riskScore &gt;= 50, 'Medium volume should add factor');
+        Assert.isTrue(riskScore &gt;= 50, 'Medium volume should add factor');
     }
     
     // ═══════════════════════════════════════════════════════════════
@@ -186,10 +186,10 @@ private class ElaroRealtimeMonitorTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, stats, 'Should return stats map');
-        System.assert(stats.containsKey('totalEvents'), 'Should contain totalEvents');
-        System.assert(stats.containsKey('criticalEvents'), 'Should contain criticalEvents');
-        System.assert(stats.containsKey('highRiskEvents'), 'Should contain highRiskEvents');
-        System.assert(stats.containsKey('timeWindow'), 'Should contain timeWindow');
+        Assert.isTrue(stats.containsKey('totalEvents'), 'Should contain totalEvents');
+        Assert.isTrue(stats.containsKey('criticalEvents'), 'Should contain criticalEvents');
+        Assert.isTrue(stats.containsKey('highRiskEvents'), 'Should contain highRiskEvents');
+        Assert.isTrue(stats.containsKey('timeWindow'), 'Should contain timeWindow');
     }
     
     @isTest
@@ -287,7 +287,7 @@ private class ElaroRealtimeMonitorTest {
         Test.stopTest();
         
         // Should handle invalid number gracefully
-        System.assert(riskScore &gt;= 0, 'Should handle invalid rows gracefully');
+        Assert.isTrue(riskScore &gt;= 0, 'Should handle invalid rows gracefully');
     }
     
     @isTest
@@ -300,6 +300,6 @@ private class ElaroRealtimeMonitorTest {
         Test.stopTest();
         
         // Should add time factor
-        System.assert(riskScore &gt; 20, 'Outside business hours should add risk');
+        Assert.isTrue(riskScore &gt; 20, 'Outside business hours should add risk');
     }
 }

--- a/force-app/main/default/classes/ElaroReasoningEngineTest.cls
+++ b/force-app/main/default/classes/ElaroReasoningEngineTest.cls
@@ -225,8 +225,8 @@ private class ElaroReasoningEngineTest {
         String explanation = ElaroReasoningEngine.buildSafeExplanation(policy, node, prediction, settings);
         Test.stopTest();
 
-        System.assert(explanation.startsWith('[REVIEW REQUIRED] '), 'Explanation should include review prefix when below threshold');
-        System.assert(explanation.contains('Flow123'), 'Explanation should include entity record id');
-        System.assert(explanation.contains('Policy description'), 'Explanation should reference policy description');
+        Assert.isTrue(explanation.startsWith('[REVIEW REQUIRED] '), 'Explanation should include review prefix when below threshold');
+        Assert.isTrue(explanation.contains('Flow123'), 'Explanation should include entity record id');
+        Assert.isTrue(explanation.contains('Policy description'), 'Explanation should reference policy description');
     }
 }

--- a/force-app/main/default/classes/ElaroSOC2ComplianceServiceTest.cls
+++ b/force-app/main/default/classes/ElaroSOC2ComplianceServiceTest.cls
@@ -29,7 +29,7 @@ private class ElaroSOC2ComplianceServiceTest {
         
         // Then: Should calculate risk score
         Assert.areNotEqual(null, score, 'Risk score should not be null');
-        System.assert(score >= 0 && score <= 10, 'Risk score should be between 0 and 10');
+        Assert.isTrue(score >= 0 && score <= 10, 'Risk score should be between 0 and 10');
     }
     
     @IsTest

--- a/force-app/main/default/classes/ElaroScheduledDeliveryTest.cls
+++ b/force-app/main/default/classes/ElaroScheduledDeliveryTest.cls
@@ -125,7 +125,7 @@ private class ElaroScheduledDeliveryTest {
         ];
         
         Assert.areEqual(cronExpression, ct.CronExpression, 'Cron expression should match');
-        System.assert(ct.CronJobDetail.Name.contains('Elaro_Delivery_'), 
+        Assert.isTrue(ct.CronJobDetail.Name.contains('Elaro_Delivery_'), 
             'Job name should contain Elaro_Delivery_');
     }
     

--- a/force-app/main/default/classes/ElaroSchedulerTests.cls
+++ b/force-app/main/default/classes/ElaroSchedulerTests.cls
@@ -94,7 +94,7 @@ private class ElaroSchedulerTests {
             WHERE Status__c = 'Overdue'
         ];
 
-        System.assertEquals(1, overdueRequests.size(), 'Should have 1 overdue request');
+        Assert.areEqual(1, overdueRequests.size(), 'Should have 1 overdue request');
     }
 
     @IsTest
@@ -105,7 +105,7 @@ private class ElaroSchedulerTests {
 
         Test.stopTest();
 
-        System.assertNotEquals(null, jobId, 'Job ID should not be null');
+        Assert.areNotEqual(null, jobId, 'Job ID should not be null');
 
         // Verify job was scheduled
         List<CronTrigger> jobs = [
@@ -113,7 +113,7 @@ private class ElaroSchedulerTests {
             FROM CronTrigger
             WHERE Id = :jobId
         ];
-        System.assertEquals(1, jobs.size(), 'Job should be scheduled');
+        Assert.areEqual(1, jobs.size(), 'Job should be scheduled');
     }
 
     @IsTest
@@ -124,7 +124,7 @@ private class ElaroSchedulerTests {
 
         Test.stopTest();
 
-        System.assertNotEquals(null, jobId, 'Job ID should not be null');
+        Assert.areNotEqual(null, jobId, 'Job ID should not be null');
     }
 
     @IsTest
@@ -140,7 +140,7 @@ private class ElaroSchedulerTests {
         Test.stopTest();
 
         // Should complete without errors
-        System.assert(true, 'Scheduler should handle empty data gracefully');
+        Assert.isTrue(true, 'Scheduler should handle empty data gracefully');
     }
 
     // ========================================
@@ -157,7 +157,7 @@ private class ElaroSchedulerTests {
         Test.stopTest();
 
         // Scheduler should complete without errors
-        System.assert(true, 'Scheduler should execute successfully');
+        Assert.isTrue(true, 'Scheduler should execute successfully');
     }
 
     @IsTest
@@ -168,7 +168,7 @@ private class ElaroSchedulerTests {
 
         Test.stopTest();
 
-        System.assertNotEquals(null, jobId, 'Job ID should not be null');
+        Assert.areNotEqual(null, jobId, 'Job ID should not be null');
 
         // Verify job was scheduled
         List<CronTrigger> jobs = [
@@ -176,7 +176,7 @@ private class ElaroSchedulerTests {
             FROM CronTrigger
             WHERE Id = :jobId
         ];
-        System.assertEquals(1, jobs.size(), 'Job should be scheduled');
+        Assert.areEqual(1, jobs.size(), 'Job should be scheduled');
     }
 
     @IsTest
@@ -192,7 +192,7 @@ private class ElaroSchedulerTests {
 
         Test.stopTest();
 
-        System.assert(true, 'Scheduler should handle no dormant users gracefully');
+        Assert.isTrue(true, 'Scheduler should handle no dormant users gracefully');
     }
 
     // ========================================
@@ -209,7 +209,7 @@ private class ElaroSchedulerTests {
         Test.stopTest();
 
         // Should complete without errors
-        System.assert(true, 'Scheduler should execute successfully');
+        Assert.isTrue(true, 'Scheduler should execute successfully');
     }
 
     @IsTest
@@ -220,7 +220,7 @@ private class ElaroSchedulerTests {
 
         Test.stopTest();
 
-        System.assertNotEquals(null, jobId, 'Job ID should not be null');
+        Assert.areNotEqual(null, jobId, 'Job ID should not be null');
 
         // Verify job was scheduled
         List<CronTrigger> jobs = [
@@ -228,7 +228,7 @@ private class ElaroSchedulerTests {
             FROM CronTrigger
             WHERE Id = :jobId
         ];
-        System.assertEquals(1, jobs.size(), 'Job should be scheduled');
+        Assert.areEqual(1, jobs.size(), 'Job should be scheduled');
     }
 
     // ========================================
@@ -245,7 +245,7 @@ private class ElaroSchedulerTests {
         Test.stopTest();
 
         // Should complete without errors
-        System.assert(true, 'Scheduler should execute successfully');
+        Assert.isTrue(true, 'Scheduler should execute successfully');
     }
 
     @IsTest
@@ -258,7 +258,7 @@ private class ElaroSchedulerTests {
         Test.stopTest();
 
         // Should complete without errors
-        System.assert(true, 'Privileged scheduler should execute successfully');
+        Assert.isTrue(true, 'Privileged scheduler should execute successfully');
     }
 
     @IsTest
@@ -269,7 +269,7 @@ private class ElaroSchedulerTests {
 
         Test.stopTest();
 
-        System.assertNotEquals(null, jobId, 'Job ID should not be null');
+        Assert.areNotEqual(null, jobId, 'Job ID should not be null');
     }
 
     @IsTest
@@ -280,7 +280,7 @@ private class ElaroSchedulerTests {
 
         Test.stopTest();
 
-        System.assertNotEquals(null, jobId, 'Job ID should not be null');
+        Assert.areNotEqual(null, jobId, 'Job ID should not be null');
     }
 
     @IsTest
@@ -292,7 +292,7 @@ private class ElaroSchedulerTests {
         Test.stopTest();
 
         // Default should run quarterly reviews
-        System.assert(true, 'Default constructor should work');
+        Assert.isTrue(true, 'Default constructor should work');
     }
 
     // ========================================
@@ -309,7 +309,7 @@ private class ElaroSchedulerTests {
         Test.stopTest();
 
         // Should complete without errors
-        System.assert(true, 'Default scheduler should execute successfully');
+        Assert.isTrue(true, 'Default scheduler should execute successfully');
     }
 
     @IsTest
@@ -322,7 +322,7 @@ private class ElaroSchedulerTests {
         Test.stopTest();
 
         // Should complete without errors
-        System.assert(true, 'Parameterized scheduler should execute successfully');
+        Assert.isTrue(true, 'Parameterized scheduler should execute successfully');
     }
 
     @IsTest
@@ -335,7 +335,7 @@ private class ElaroSchedulerTests {
         Test.stopTest();
 
         // Should use defaults and complete without errors
-        System.assert(true, 'Scheduler should handle null parameters gracefully');
+        Assert.isTrue(true, 'Scheduler should handle null parameters gracefully');
     }
 
     // ========================================
@@ -367,7 +367,7 @@ private class ElaroSchedulerTests {
 
         // Verify some requests were marked overdue
         Integer overdueCount = [SELECT COUNT() FROM CCPA_Request__c WHERE Status__c = 'Overdue'];
-        System.assert(overdueCount > 0, 'Should have some overdue requests');
+        Assert.isTrue(overdueCount > 0, 'Should have some overdue requests');
     }
 
     // ========================================
@@ -392,7 +392,7 @@ private class ElaroSchedulerTests {
 
         Test.stopTest();
 
-        System.assert(true, 'All schedulers should handle empty data gracefully');
+        Assert.isTrue(true, 'All schedulers should handle empty data gracefully');
     }
 
     @IsTest
@@ -408,9 +408,9 @@ private class ElaroSchedulerTests {
         Test.stopTest();
 
         // All jobs should be scheduled
-        System.assertNotEquals(null, job1, 'CCPA job should be scheduled');
-        System.assertNotEquals(null, job2, 'Dormant Account job should be scheduled');
-        System.assertNotEquals(null, job3, 'GLBA job should be scheduled');
-        System.assertNotEquals(null, job4, 'ISO 27001 job should be scheduled');
+        Assert.areNotEqual(null, job1, 'CCPA job should be scheduled');
+        Assert.areNotEqual(null, job2, 'Dormant Account job should be scheduled');
+        Assert.areNotEqual(null, job3, 'GLBA job should be scheduled');
+        Assert.areNotEqual(null, job4, 'ISO 27001 job should be scheduled');
     }
 }

--- a/force-app/main/default/classes/ElaroSecurityUtilsPermissionTest.cls
+++ b/force-app/main/default/classes/ElaroSecurityUtilsPermissionTest.cls
@@ -159,7 +159,7 @@ private class ElaroSecurityUtilsPermissionTest {
                 ElaroSecurityUtils.validateCRUDAccess('InvalidObject__c', ElaroSecurityUtils.DmlOperation.DML_INSERT);
                 Assert.fail( 'Should have thrown SecurityException');
             } catch (ElaroSecurityUtils.SecurityException e) {
-                System.assert(e.getMessage().contains('Insufficient'), 
+                Assert.isTrue(e.getMessage().contains('Insufficient'), 
                     'Should throw SecurityException with insufficient access message: ' + e.getMessage());
             }
         }
@@ -201,7 +201,7 @@ private class ElaroSecurityUtilsPermissionTest {
                 // May not throw if field doesn't exist
                 Assert.isTrue(true, 'Validation may pass for non-existent field');
             } catch (ElaroSecurityUtils.SecurityException e) {
-                System.assert(e.getMessage().contains('Insufficient FLS'), 
+                Assert.isTrue(e.getMessage().contains('Insufficient FLS'), 
                     'Should throw SecurityException for insufficient FLS: ' + e.getMessage());
             }
         }

--- a/force-app/main/default/classes/ElaroSecurityUtilsTest.cls
+++ b/force-app/main/default/classes/ElaroSecurityUtilsTest.cls
@@ -133,7 +133,7 @@ private class ElaroSecurityUtilsTest {
         }
         Test.stopTest();
 
-        System.assert(validationPassed, 'Insert access validation should complete successfully');
+        Assert.isTrue(validationPassed, 'Insert access validation should complete successfully');
     }
     
     @IsTest
@@ -151,7 +151,7 @@ private class ElaroSecurityUtilsTest {
         }
         Test.stopTest();
 
-        System.assert(validationPassed, 'Update access validation should complete successfully');
+        Assert.isTrue(validationPassed, 'Update access validation should complete successfully');
     }
     
     @IsTest
@@ -169,7 +169,7 @@ private class ElaroSecurityUtilsTest {
         }
         Test.stopTest();
 
-        System.assert(validationPassed, 'Delete access validation should complete successfully');
+        Assert.isTrue(validationPassed, 'Delete access validation should complete successfully');
     }
     
     @IsTest
@@ -187,7 +187,7 @@ private class ElaroSecurityUtilsTest {
         }
         Test.stopTest();
 
-        System.assert(validationPassed, 'Upsert access validation should complete successfully');
+        Assert.isTrue(validationPassed, 'Upsert access validation should complete successfully');
     }
     
     @IsTest
@@ -204,7 +204,7 @@ private class ElaroSecurityUtilsTest {
         }
         Test.stopTest();
 
-        System.assert(validationPassed, 'FLS read validation should complete successfully for accessible fields');
+        Assert.isTrue(validationPassed, 'FLS read validation should complete successfully for accessible fields');
     }
     
     @IsTest
@@ -221,7 +221,7 @@ private class ElaroSecurityUtilsTest {
         }
         Test.stopTest();
 
-        System.assert(validationPassed, 'FLS write validation should complete successfully for writable fields');
+        Assert.isTrue(validationPassed, 'FLS write validation should complete successfully for writable fields');
     }
     
     @IsTest
@@ -232,9 +232,9 @@ private class ElaroSecurityUtilsTest {
         String secureQuery = ElaroSecurityUtils.buildSecureQuery(baseQuery);
         Test.stopTest();
         
-        System.assert(secureQuery.contains('WITH USER_MODE'), 
+        Assert.isTrue(secureQuery.contains('WITH USER_MODE'), 
             'Should add WITH USER_MODE');
-        System.assert(secureQuery.contains('SELECT Id, Name FROM Account'), 
+        Assert.isTrue(secureQuery.contains('SELECT Id, Name FROM Account'), 
             'Should preserve original query');
     }
     
@@ -326,7 +326,7 @@ private class ElaroSecurityUtilsTest {
             ElaroSecurityUtils.validateFLSAccess('Account', fields, false);
             Assert.fail( 'Should throw exception for invalid field');
         } catch (ElaroSecurityUtils.SecurityException e) {
-            System.assert(e.getMessage().contains('Insufficient FLS access'),
+            Assert.isTrue(e.getMessage().contains('Insufficient FLS access'),
                 'Exception should mention FLS access');
         }
         Test.stopTest();
@@ -341,7 +341,7 @@ private class ElaroSecurityUtilsTest {
             ElaroSecurityUtils.validateFLSAccess('Account', fields, true);
             Assert.fail( 'Should throw exception for invalid field write');
         } catch (ElaroSecurityUtils.SecurityException e) {
-            System.assert(e.getMessage().contains('Insufficient FLS access'),
+            Assert.isTrue(e.getMessage().contains('Insufficient FLS access'),
                 'Exception should mention FLS access');
         }
         Test.stopTest();
@@ -357,7 +357,7 @@ private class ElaroSecurityUtilsTest {
             );
             Assert.fail( 'Should throw exception for invalid object');
         } catch (ElaroSecurityUtils.SecurityException e) {
-            System.assert(e.getMessage().contains('Insufficient CRUD access'),
+            Assert.isTrue(e.getMessage().contains('Insufficient CRUD access'),
                 'Exception should mention CRUD access');
         }
         Test.stopTest();
@@ -400,9 +400,9 @@ private class ElaroSecurityUtilsTest {
         String secureQuery = ElaroSecurityUtils.buildSecureQuery(baseQuery);
         Test.stopTest();
 
-        System.assert(secureQuery.contains('WITH USER_MODE'),
+        Assert.isTrue(secureQuery.contains('WITH USER_MODE'),
             'Should add WITH USER_MODE');
-        System.assert(secureQuery.contains('WHERE Name != null'),
+        Assert.isTrue(secureQuery.contains('WHERE Name != null'),
             'Should preserve WHERE clause');
     }
 

--- a/force-app/main/default/classes/ElaroSharingViolationTest.cls
+++ b/force-app/main/default/classes/ElaroSharingViolationTest.cls
@@ -81,7 +81,7 @@ private class ElaroSharingViolationTest {
                 WITH USER_MODE
             ];
             // With sharing enforced, query may return empty or throw exception
-            System.assert(otherAccounts.isEmpty() || otherAccounts.size() == 0, 
+            Assert.isTrue(otherAccounts.isEmpty() || otherAccounts.size() == 0, 
                 'Owner1 should not see Owner2\'s account due to sharing');
         }
         Test.stopTest();
@@ -105,7 +105,7 @@ private class ElaroSharingViolationTest {
             ];
             
             Assert.areNotEqual(null, accounts, 'Accounts list should not be null');
-            System.assert(accounts.size() >= 0, 'Should return accounts respecting sharing');
+            Assert.isTrue(accounts.size() >= 0, 'Should return accounts respecting sharing');
         }
         Test.stopTest();
     }
@@ -154,7 +154,7 @@ private class ElaroSharingViolationTest {
                     WITH USER_MODE
                 ];
                 // Query may return empty due to sharing
-                System.assert(accounts.isEmpty() || accounts.size() == 0, 
+                Assert.isTrue(accounts.isEmpty() || accounts.size() == 0, 
                     'Should not return records due to sharing violation');
             } catch (QueryException e) {
                 // QueryException may be thrown for sharing violations
@@ -180,7 +180,7 @@ private class ElaroSharingViolationTest {
             ];
             
             // Should return at least owner1's account
-            System.assert(allAccounts.size() >= 1, 'Should return at least one account');
+            Assert.isTrue(allAccounts.size() >= 1, 'Should return at least one account');
         }
         Test.stopTest();
     }

--- a/force-app/main/default/classes/ElaroShieldServiceTest.cls
+++ b/force-app/main/default/classes/ElaroShieldServiceTest.cls
@@ -37,9 +37,9 @@ private class ElaroShieldServiceTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, status, 'Should return status map');
-        System.assert(status.containsKey('shieldEnabled'), 'Should contain shieldEnabled key');
-        System.assert(status.containsKey('platformEncryption'), 'Should contain platformEncryption key');
-        System.assert(status.containsKey('eventMonitoring'), 'Should contain eventMonitoring key');
+        Assert.isTrue(status.containsKey('shieldEnabled'), 'Should contain shieldEnabled key');
+        Assert.isTrue(status.containsKey('platformEncryption'), 'Should contain platformEncryption key');
+        Assert.isTrue(status.containsKey('eventMonitoring'), 'Should contain eventMonitoring key');
     }
     
     // ═══════════════════════════════════════════════════════════════
@@ -146,9 +146,9 @@ private class ElaroShieldServiceTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, riskLevels, 'Should return risk levels map');
-        System.assert(!riskLevels.isEmpty(), 'Map should not be empty');
-        System.assert(riskLevels.containsKey('Login'), 'Should contain Login');
-        System.assert(riskLevels.containsKey('LoginAs'), 'Should contain LoginAs');
+        Assert.isTrue(!riskLevels.isEmpty(), 'Map should not be empty');
+        Assert.isTrue(riskLevels.containsKey('Login'), 'Should contain Login');
+        Assert.isTrue(riskLevels.containsKey('LoginAs'), 'Should contain LoginAs');
     }
     
     // ═══════════════════════════════════════════════════════════════
@@ -166,7 +166,7 @@ private class ElaroShieldServiceTest {
             );
             Assert.fail( 'Should have thrown exception');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Invalid event type'), 
+            Assert.isTrue(e.getMessage().contains('Invalid event type'), 
                 'Should mention invalid event type');
         }
         Test.stopTest();
@@ -179,7 +179,7 @@ private class ElaroShieldServiceTest {
             ElaroShieldService.getEventLogFiles('Login', null, null);
             Assert.fail( 'Should have thrown exception');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 
+            Assert.isTrue(e.getMessage().contains('required'), 
                 'Should mention required dates');
         }
         Test.stopTest();
@@ -196,7 +196,7 @@ private class ElaroShieldServiceTest {
             );
             Assert.fail( 'Should have thrown exception');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('before'), 
+            Assert.isTrue(e.getMessage().contains('before'), 
                 'Should mention date order');
         }
         Test.stopTest();
@@ -227,7 +227,7 @@ private class ElaroShieldServiceTest {
             ElaroShieldService.parseEventLogContent(null);
             Assert.fail( 'Should have thrown exception');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 
+            Assert.isTrue(e.getMessage().contains('required'), 
                 'Should mention required ID');
         }
         Test.stopTest();
@@ -240,7 +240,7 @@ private class ElaroShieldServiceTest {
             ElaroShieldService.parseEventLogContent('');
             Assert.fail( 'Should have thrown exception');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 
+            Assert.isTrue(e.getMessage().contains('required'), 
                 'Should mention required ID');
         }
         Test.stopTest();
@@ -274,7 +274,7 @@ private class ElaroShieldServiceTest {
             );
             Assert.fail( 'Should have thrown exception');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Invalid event type'), 
+            Assert.isTrue(e.getMessage().contains('Invalid event type'), 
                 'Should mention invalid event type');
         }
         Test.stopTest();

--- a/force-app/main/default/classes/ElaroSlackNotifierQueueableTest.cls
+++ b/force-app/main/default/classes/ElaroSlackNotifierQueueableTest.cls
@@ -150,7 +150,7 @@ private class ElaroSlackNotifierQueueableTest {
         Test.stopTest();
 
         Assert.isTrue(true, 'Bulk notifications should complete');
-        System.assert(Limits.getQueueableJobs() <= 50, 'Should stay under queueable limit');
+        Assert.isTrue(Limits.getQueueableJobs() <= 50, 'Should stay under queueable limit');
     }
 
     @IsTest

--- a/force-app/main/default/classes/ElaroTrendControllerTest.cls
+++ b/force-app/main/default/classes/ElaroTrendControllerTest.cls
@@ -37,7 +37,7 @@ private class ElaroTrendControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for invalid object');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for invalid object');
     }
 
     @isTest
@@ -61,7 +61,7 @@ private class ElaroTrendControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for invalid object');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for invalid object');
     }
 
     @isTest
@@ -182,7 +182,7 @@ private class ElaroTrendControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for invalid object');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for invalid object');
     }
 
     @isTest
@@ -202,7 +202,7 @@ private class ElaroTrendControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for null object API name');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for null object API name');
     }
 
     @isTest
@@ -222,7 +222,7 @@ private class ElaroTrendControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for invalid granularity');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for invalid granularity');
     }
 
     @isTest
@@ -242,7 +242,7 @@ private class ElaroTrendControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for blank date field');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for blank date field');
     }
 
     @isTest
@@ -262,7 +262,7 @@ private class ElaroTrendControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for blank metric field');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for blank metric field');
     }
 
     @isTest
@@ -282,7 +282,7 @@ private class ElaroTrendControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for blank granularity');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for blank granularity');
     }
 
     @isTest
@@ -382,7 +382,7 @@ private class ElaroTrendControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for non-date field');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for non-date field');
     }
 
     @isTest
@@ -402,7 +402,7 @@ private class ElaroTrendControllerTest {
             exceptionThrown = true;
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Should have thrown exception for invalid field');
+        Assert.isTrue(exceptionThrown, 'Should have thrown exception for invalid field');
     }
 
     @isTest

--- a/force-app/main/default/classes/EscalationPathControllerTest.cls
+++ b/force-app/main/default/classes/EscalationPathControllerTest.cls
@@ -107,7 +107,7 @@ private class EscalationPathControllerTest {
             EscalationPathController.createPath(path);
             Assert.fail( 'Expected exception for missing user');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('User'), 'Error message should mention user');
+            Assert.isTrue(e.getMessage().contains('User'), 'Error message should mention user');
         }
         Test.stopTest();
     }
@@ -129,7 +129,7 @@ private class EscalationPathControllerTest {
             EscalationPathController.createPath(path);
             Assert.fail( 'Expected exception for invalid level');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Level'), 'Error message should mention level');
+            Assert.isTrue(e.getMessage().contains('Level'), 'Error message should mention level');
         }
         Test.stopTest();
     }
@@ -151,7 +151,7 @@ private class EscalationPathControllerTest {
             EscalationPathController.createPath(path);
             Assert.fail( 'Expected exception for invalid level');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Level'), 'Error message should mention level');
+            Assert.isTrue(e.getMessage().contains('Level'), 'Error message should mention level');
         }
         Test.stopTest();
     }
@@ -173,7 +173,7 @@ private class EscalationPathControllerTest {
             EscalationPathController.createPath(path);
             Assert.fail( 'Expected exception for invalid delay');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('delay'), 'Error message should mention delay');
+            Assert.isTrue(e.getMessage().contains('delay'), 'Error message should mention delay');
         }
         Test.stopTest();
     }
@@ -195,7 +195,7 @@ private class EscalationPathControllerTest {
             EscalationPathController.createPath(path);
             Assert.fail( 'Expected exception for null delay');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('delay'), 'Error message should mention delay');
+            Assert.isTrue(e.getMessage().contains('delay'), 'Error message should mention delay');
         }
         Test.stopTest();
     }

--- a/force-app/main/default/classes/EvidenceCollectionServiceTest.cls
+++ b/force-app/main/default/classes/EvidenceCollectionServiceTest.cls
@@ -20,7 +20,7 @@ private class EvidenceCollectionServiceTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, evidence, 'Evidence list should not be null');
-        System.assert(!evidence.isEmpty(), 'Should have collected evidence');
+        Assert.isTrue(!evidence.isEmpty(), 'Should have collected evidence');
         
         // Verify evidence was inserted
         List<Compliance_Evidence__c> insertedEvidence = [
@@ -29,7 +29,7 @@ private class EvidenceCollectionServiceTest {
             WHERE Framework__c = 'SOX'
             WITH USER_MODE
         ];
-        System.assert(!insertedEvidence.isEmpty(), 'Evidence should be inserted');
+        Assert.isTrue(!insertedEvidence.isEmpty(), 'Evidence should be inserted');
     }
     
     @IsTest
@@ -93,13 +93,13 @@ private class EvidenceCollectionServiceTest {
         }
         Test.stopTest();
         
-        System.assert(!allEvidence.isEmpty(), 'Should collect evidence for all frameworks');
+        Assert.isTrue(!allEvidence.isEmpty(), 'Should collect evidence for all frameworks');
         
         // Verify evidence was inserted for each framework
         Integer totalEvidenceCount = [
             SELECT COUNT() FROM Compliance_Evidence__c
         ];
-        System.assert(totalEvidenceCount >= frameworks.size(), 
+        Assert.isTrue(totalEvidenceCount >= frameworks.size(), 
             'Should have at least one evidence record per framework');
     }
     
@@ -115,7 +115,7 @@ private class EvidenceCollectionServiceTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, evidence, 'Evidence list should not be null');
-        System.assert(!evidence.isEmpty(), 'Should collect evidence for large date range');
+        Assert.isTrue(!evidence.isEmpty(), 'Should collect evidence for large date range');
     }
 
     @IsTest
@@ -140,9 +140,9 @@ private class EvidenceCollectionServiceTest {
         Assert.areNotEqual(null, evidence, 'Evidence list should not be null');
 
         // Verify governor limits were not exceeded
-        System.assert(Limits.getQueries() < 100,
+        Assert.isTrue(Limits.getQueries() < 100,
             'SOQL queries should be within limits: ' + Limits.getQueries());
-        System.assert(Limits.getDmlStatements() < 150,
+        Assert.isTrue(Limits.getDmlStatements() < 150,
             'DML statements should be within limits: ' + Limits.getDmlStatements());
     }
 

--- a/force-app/main/default/classes/FINRAModuleTest.cls
+++ b/force-app/main/default/classes/FINRAModuleTest.cls
@@ -77,15 +77,15 @@ private class FINRAModuleTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, controls, 'Controls list should not be null');
-        System.assert(controls.size() > 0, 'Should have at least one control');
+        Assert.isTrue(controls.size() > 0, 'Should have at least one control');
 
         Set<String> categories = new Set<String>();
         for (IComplianceModule.Control ctrl : controls) {
             categories.add(ctrl.category);
         }
-        System.assert(categories.contains('Supervision'), 'Should include Supervision controls');
-        System.assert(categories.contains('Records'), 'Should include Records controls');
-        System.assert(categories.contains('BCP'), 'Should include BCP controls');
+        Assert.isTrue(categories.contains('Supervision'), 'Should include Supervision controls');
+        Assert.isTrue(categories.contains('Records'), 'Should include Records controls');
+        Assert.isTrue(categories.contains('BCP'), 'Should include BCP controls');
     }
 
     @IsTest
@@ -98,7 +98,7 @@ private class FINRAModuleTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, score, 'Score should not be null');
-        System.assert(score >= 0, 'Score should be >= 0');
+        Assert.isTrue(score >= 0, 'Score should be >= 0');
     }
 
     @IsTest
@@ -123,7 +123,7 @@ private class FINRAModuleTest {
 
         Assert.areNotEqual(null, gaps, 'Gaps list should not be null');
         for (IComplianceModule.Gap gap : gaps) {
-            System.assert(gap.id.startsWith('GAP-FINRA-'), 'Gap ID should start with GAP-FINRA-');
+            Assert.isTrue(gap.id.startsWith('GAP-FINRA-'), 'Gap ID should start with GAP-FINRA-');
             Assert.areNotEqual(null, gap.recommendation, 'Gap recommendation should not be null');
         }
     }
@@ -210,7 +210,7 @@ private class FINRAModuleTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, result, 'Result should not be null');
-        System.assert(result.passed, 'Record keeping should pass');
+        Assert.isTrue(result.passed, 'Record keeping should pass');
         Assert.areEqual(90, result.score, 'Score should be 90');
     }
 

--- a/force-app/main/default/classes/FlowExecutionLoggerTest.cls
+++ b/force-app/main/default/classes/FlowExecutionLoggerTest.cls
@@ -166,7 +166,7 @@ private class FlowExecutionLoggerTest {
             FlowExecutionLogger.log('', null, 'SUCCESS', 100, 5, 2);
             Assert.fail( 'Should have thrown exception for blank flow name');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Flow name cannot be blank'), 'Expected flow name validation error');
+            Assert.isTrue(e.getMessage().contains('Flow name cannot be blank'), 'Expected flow name validation error');
         }
 
         // Test null flow name
@@ -174,7 +174,7 @@ private class FlowExecutionLoggerTest {
             FlowExecutionLogger.log(null, null, 'SUCCESS', 100, 5, 2);
             Assert.fail( 'Should have thrown exception for null flow name');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Flow name cannot be blank'), 'Expected flow name validation error');
+            Assert.isTrue(e.getMessage().contains('Flow name cannot be blank'), 'Expected flow name validation error');
         }
 
         // Test blank status
@@ -182,7 +182,7 @@ private class FlowExecutionLoggerTest {
             FlowExecutionLogger.log('TestFlow', null, '', 100, 5, 2);
             Assert.fail( 'Should have thrown exception for blank status');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Status cannot be blank'), 'Expected status validation error');
+            Assert.isTrue(e.getMessage().contains('Status cannot be blank'), 'Expected status validation error');
         }
 
         // Test null status
@@ -190,7 +190,7 @@ private class FlowExecutionLoggerTest {
             FlowExecutionLogger.log('TestFlow', null, null, 100, 5, 2);
             Assert.fail( 'Should have thrown exception for null status');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Status cannot be blank'), 'Expected status validation error');
+            Assert.isTrue(e.getMessage().contains('Status cannot be blank'), 'Expected status validation error');
         }
 
         Test.stopTest();

--- a/force-app/main/default/classes/FlowExecutionStatsTest.cls
+++ b/force-app/main/default/classes/FlowExecutionStatsTest.cls
@@ -30,7 +30,7 @@ private class FlowExecutionStatsTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, results, 'Results should not be null');
-        System.assert(!results.isEmpty(), 'Should return at least one result');
+        Assert.isTrue(!results.isEmpty(), 'Should return at least one result');
     }
     
     @IsTest
@@ -39,7 +39,7 @@ private class FlowExecutionStatsTest {
         List<FlowExecutionStats.ExecAgg> results = FlowExecutionStats.getTopFlows(2);
         Test.stopTest();
         
-        System.assert(results.size() <= 2, 'Should respect limit');
+        Assert.isTrue(results.size() <= 2, 'Should respect limit');
     }
     
     @IsTest
@@ -51,7 +51,7 @@ private class FlowExecutionStatsTest {
         // Verify fault counts are included
         for (FlowExecutionStats.ExecAgg agg : results) {
             Assert.areNotEqual(null, agg.faults, 'Fault count should not be null');
-            System.assert(agg.faults >= 0, 'Fault count should be non-negative');
+            Assert.isTrue(agg.faults >= 0, 'Fault count should be non-negative');
         }
     }
     
@@ -62,7 +62,7 @@ private class FlowExecutionStatsTest {
         Test.stopTest();
         
         // Should default to at least 1
-        System.assert(results.size() >= 1, 'Should return at least 1 result even with 0 limit');
+        Assert.isTrue(results.size() >= 1, 'Should return at least 1 result even with 0 limit');
     }
     
     @IsTest
@@ -72,7 +72,7 @@ private class FlowExecutionStatsTest {
         Test.stopTest();
         
         // Should default to at least 1
-        System.assert(results.size() >= 1, 'Should return at least 1 result even with negative limit');
+        Assert.isTrue(results.size() >= 1, 'Should return at least 1 result even with negative limit');
     }
     
     @IsTest

--- a/force-app/main/default/classes/GDPRBreachNotificationServiceTest.cls
+++ b/force-app/main/default/classes/GDPRBreachNotificationServiceTest.cls
@@ -58,7 +58,7 @@ private class GDPRBreachNotificationServiceTest {
         }
         Test.stopTest();
         
-        System.assert(breachIds.size() > 0, 'Should process bulk breaches');
+        Assert.isTrue(breachIds.size() > 0, 'Should process bulk breaches');
     }
     
     @IsTest
@@ -158,7 +158,7 @@ private class GDPRBreachNotificationServiceTest {
             service.reportBreach(null, 100, 'Test');
             Assert.fail( 'Should throw exception for null breach date');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should validate required parameters');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should validate required parameters');
         }
         Test.stopTest();
     }
@@ -173,7 +173,7 @@ private class GDPRBreachNotificationServiceTest {
             service.assessSeverity(fakeId);
             Assert.fail( 'Should throw exception for non-existent breach');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required') || e.getMessage().contains('not found'), 
+            Assert.isTrue(e.getMessage().contains('required') || e.getMessage().contains('not found'), 
                 'Should handle missing breach');
         }
         Test.stopTest();

--- a/force-app/main/default/classes/GDPRConsentManagementServiceTest.cls
+++ b/force-app/main/default/classes/GDPRConsentManagementServiceTest.cls
@@ -68,7 +68,7 @@ private class GDPRConsentManagementServiceTest {
         }
         Test.stopTest();
         
-        System.assert(consentIds.size() > 0, 'Should process bulk consents');
+        Assert.isTrue(consentIds.size() > 0, 'Should process bulk consents');
     }
     
     @IsTest
@@ -90,7 +90,7 @@ private class GDPRConsentManagementServiceTest {
             WHERE Contact__c = :testContact.Id 
             AND Consent_Type__c = 'Marketing'
         ];
-        System.assert(withdrawnConsents.size() > 0, 'Consents should be withdrawn');
+        Assert.isTrue(withdrawnConsents.size() > 0, 'Consents should be withdrawn');
     }
     
     @IsTest
@@ -104,7 +104,7 @@ private class GDPRConsentManagementServiceTest {
         List<Consent__c> history = service.getConsentHistory(testContact.Id);
         Test.stopTest();
         
-        System.assert(history.size() > 0, 'Should return consent history');
+        Assert.isTrue(history.size() > 0, 'Should return consent history');
     }
     
     @IsTest
@@ -162,7 +162,7 @@ private class GDPRConsentManagementServiceTest {
             service.recordConsent(null, 'Marketing', true, 'Web');
             Assert.fail( 'Should throw exception for null contact');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should validate required parameters');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should validate required parameters');
         }
         Test.stopTest();
     }

--- a/force-app/main/default/classes/GDPRDataInventoryServiceTest.cls
+++ b/force-app/main/default/classes/GDPRDataInventoryServiceTest.cls
@@ -42,8 +42,8 @@ private class GDPRDataInventoryServiceTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, inventory, 'Inventory should not be null');
-        System.assert(inventory.containsKey('totalActivities'), 'Should include activity count');
-        System.assert(inventory.containsKey('totalRecipients'), 'Should include recipient count');
+        Assert.isTrue(inventory.containsKey('totalActivities'), 'Should include activity count');
+        Assert.isTrue(inventory.containsKey('totalRecipients'), 'Should include recipient count');
     }
     
     @IsTest
@@ -59,7 +59,7 @@ private class GDPRDataInventoryServiceTest {
             Assert.areNotEqual(null, evidence, 'Evidence should not be null');
         } catch (Exception e) {
             // May fail if control doesn't exist - that's expected in test
-            System.assert(e.getMessage().contains('Control not found') || e.getMessage().contains('required'), 
+            Assert.isTrue(e.getMessage().contains('Control not found') || e.getMessage().contains('required'), 
                 'Should handle missing control gracefully');
         }
         Test.stopTest();
@@ -77,7 +77,7 @@ private class GDPRDataInventoryServiceTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, classification, 'Classification should not be null');
-        System.assert(classification.containsKey('categories'), 'Should include categories');
+        Assert.isTrue(classification.containsKey('categories'), 'Should include categories');
         Assert.areEqual(6, classification.get('totalFields'), 'Should classify all fields');
     }
     
@@ -132,7 +132,7 @@ private class GDPRDataInventoryServiceTest {
             service.generateEvidenceReport('INVALID', parameters);
             Assert.fail( 'Should throw exception for invalid report type');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Unsupported'), 'Should throw unsupported error');
+            Assert.isTrue(e.getMessage().contains('Unsupported'), 'Should throw unsupported error');
         }
         Test.stopTest();
     }

--- a/force-app/main/default/classes/GDPRDataSubjectServiceTest.cls
+++ b/force-app/main/default/classes/GDPRDataSubjectServiceTest.cls
@@ -55,7 +55,7 @@ private class GDPRDataSubjectServiceTest {
         }
         Test.stopTest();
         
-        System.assert(results.size() > 0, 'Should process bulk requests');
+        Assert.isTrue(results.size() > 0, 'Should process bulk requests');
     }
     
     @IsTest
@@ -116,7 +116,7 @@ private class GDPRDataSubjectServiceTest {
             Map<String, Object> result = service.handlePortabilityRequest(requestId, testContact.Id, format);
             Assert.fail( 'Should throw exception for invalid format');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Invalid'), 'Should throw invalid format error');
+            Assert.isTrue(e.getMessage().contains('Invalid'), 'Should throw invalid format error');
         }
         Test.stopTest();
     }
@@ -161,7 +161,7 @@ private class GDPRDataSubjectServiceTest {
             service.handleAccessRequest(null, testContact.Id);
             Assert.fail( 'Should throw exception for null request ID');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should validate required parameters');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should validate required parameters');
         }
         Test.stopTest();
     }
@@ -177,7 +177,7 @@ private class GDPRDataSubjectServiceTest {
             service.handleErasureRequest(requestId, testContact.Id, null);
             Assert.fail( 'Should throw exception for null reason');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should validate required parameters');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should validate required parameters');
         }
         Test.stopTest();
     }

--- a/force-app/main/default/classes/GDPRModuleTest.cls
+++ b/force-app/main/default/classes/GDPRModuleTest.cls
@@ -97,7 +97,7 @@ private class GDPRModuleTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, controls, 'Controls list should not be null');
-        System.assert(controls.size() > 0, 'Should have at least one control');
+        Assert.isTrue(controls.size() > 0, 'Should have at least one control');
 
         Set<String> families = new Set<String>();
         for (IComplianceModule.Control ctrl : controls) {
@@ -105,7 +105,7 @@ private class GDPRModuleTest {
             Assert.areNotEqual(null, ctrl.code, 'Control code should not be null');
             Assert.areNotEqual(null, ctrl.name, 'Control name should not be null');
         }
-        System.assert(families.size() > 1, 'Should cover multiple GDPR families');
+        Assert.isTrue(families.size() > 1, 'Should cover multiple GDPR families');
     }
 
     // =============================================
@@ -122,7 +122,7 @@ private class GDPRModuleTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, score, 'Score should not be null');
-        System.assert(score >= 0, 'Score should be >= 0');
+        Assert.isTrue(score >= 0, 'Score should be >= 0');
     }
 
     @IsTest
@@ -151,7 +151,7 @@ private class GDPRModuleTest {
 
         Assert.areNotEqual(null, gaps, 'Gaps list should not be null');
         for (IComplianceModule.Gap gap : gaps) {
-            System.assert(gap.id.startsWith('GAP-GDPR-'), 'Gap ID should start with GAP-GDPR-');
+            Assert.isTrue(gap.id.startsWith('GAP-GDPR-'), 'Gap ID should start with GAP-GDPR-');
             Assert.areNotEqual(null, gap.controlCode, 'Gap controlCode should not be null');
             Assert.areNotEqual(null, gap.recommendation, 'Gap recommendation should not be null');
         }
@@ -250,7 +250,7 @@ private class GDPRModuleTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, result, 'Result should not be null');
-        System.assert(result.passed, 'Security measures should pass');
+        Assert.isTrue(result.passed, 'Security measures should pass');
         Assert.areEqual(90, result.score, 'Score should be 90');
     }
 

--- a/force-app/main/default/classes/HIPAAAuditControlServiceTest.cls
+++ b/force-app/main/default/classes/HIPAAAuditControlServiceTest.cls
@@ -53,7 +53,7 @@ public class HIPAAAuditControlServiceTest {
         Decimal score = service.getComplianceScore();
         Test.stopTest();
 
-        System.assert(score >= 0 && score <= 100, 'Score should be between 0 and 100');
+        Assert.isTrue(score >= 0 && score <= 100, 'Score should be between 0 and 100');
     }
 
     @isTest
@@ -135,7 +135,7 @@ public class HIPAAAuditControlServiceTest {
         Assert.areNotEqual(null, docId, 'Document ID should not be null');
 
         ContentDocument doc = [SELECT Title FROM ContentDocument WHERE Id = :docId];
-        System.assert(doc.Title.contains('HIPAA_Audit_Report'), 'Title should contain HIPAA_Audit_Report');
+        Assert.isTrue(doc.Title.contains('HIPAA_Audit_Report'), 'Title should contain HIPAA_Audit_Report');
     }
 
     @isTest
@@ -222,7 +222,7 @@ public class HIPAAAuditControlServiceTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, violations, 'Violations should not be null');
-        System.assert(score >= 0, 'Score should be non-negative');
+        Assert.isTrue(score >= 0, 'Score should be non-negative');
         Assert.areNotEqual(null, result, 'Result should not be null');
     }
 }

--- a/force-app/main/default/classes/HIPAABreachNotificationServiceTest.cls
+++ b/force-app/main/default/classes/HIPAABreachNotificationServiceTest.cls
@@ -98,7 +98,7 @@ public class HIPAABreachNotificationServiceTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, violations, 'Violations should not be null');
-        System.assert(violations.size() > 0, 'Should have violations for overdue breaches');
+        Assert.isTrue(violations.size() > 0, 'Should have violations for overdue breaches');
     }
 
     @isTest
@@ -109,7 +109,7 @@ public class HIPAABreachNotificationServiceTest {
         Decimal score = service.getComplianceScore();
         Test.stopTest();
 
-        System.assert(score >= 0 && score <= 100, 'Score should be between 0 and 100');
+        Assert.isTrue(score >= 0 && score <= 100, 'Score should be between 0 and 100');
     }
 
     @isTest
@@ -155,7 +155,7 @@ public class HIPAABreachNotificationServiceTest {
         IBreachNotificationService.BreachAssessment assessment = service.assessBreach(request);
         Test.stopTest();
 
-        System.assert(assessment.overallRiskScore < 5, 'Low risk scenario should have low score');
+        Assert.isTrue(assessment.overallRiskScore < 5, 'Low risk scenario should have low score');
     }
 
     @isTest
@@ -188,8 +188,8 @@ public class HIPAABreachNotificationServiceTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, summary, 'Summary should not be null');
-        System.assert(summary.totalBreaches >= 4, 'Should have at least 4 breaches from test data');
-        System.assert(summary.openBreaches > 0, 'Should have open breaches');
+        Assert.isTrue(summary.totalBreaches >= 4, 'Should have at least 4 breaches from test data');
+        Assert.isTrue(summary.openBreaches > 0, 'Should have open breaches');
     }
 
     @isTest
@@ -201,7 +201,7 @@ public class HIPAABreachNotificationServiceTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, metrics, 'Metrics should not be null');
-        System.assert(metrics.totalBreaches >= 4, 'Should have at least 4 breaches');
+        Assert.isTrue(metrics.totalBreaches >= 4, 'Should have at least 4 breaches');
         Assert.areNotEqual(null, metrics.breachesByType, 'Breaches by type should not be null');
         Assert.areNotEqual(null, metrics.breachesByRiskLevel, 'Breaches by risk level should not be null');
     }
@@ -237,7 +237,7 @@ public class HIPAABreachNotificationServiceTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, pending, 'Pending list should not be null');
-        System.assert(pending.size() > 0, 'Should have pending breaches');
+        Assert.isTrue(pending.size() > 0, 'Should have pending breaches');
     }
 
     @isTest
@@ -304,7 +304,7 @@ public class HIPAABreachNotificationServiceTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, timeline, 'Timeline should not be null');
-        System.assert(timeline.size() >= 3, 'Should have at least 3 events');
+        Assert.isTrue(timeline.size() >= 3, 'Should have at least 3 events');
     }
 
     @isTest
@@ -330,6 +330,6 @@ public class HIPAABreachNotificationServiceTest {
         IBreachNotificationService.BreachSummary summary = service.getBreachSummary();
         Test.stopTest();
 
-        System.assert(summary.totalBreaches >= 100, 'Should handle bulk breaches');
+        Assert.isTrue(summary.totalBreaches >= 100, 'Should handle bulk breaches');
     }
 }

--- a/force-app/main/default/classes/HIPAAModuleTest.cls
+++ b/force-app/main/default/classes/HIPAAModuleTest.cls
@@ -90,7 +90,7 @@ private class HIPAAModuleTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, controls, 'Controls list should not be null');
-        System.assert(controls.size() > 0, 'Should have at least one control');
+        Assert.isTrue(controls.size() > 0, 'Should have at least one control');
 
         // Verify controls cover Administrative, Physical, and Technical safeguards
         Set<String> categories = new Set<String>();
@@ -100,9 +100,9 @@ private class HIPAAModuleTest {
             Assert.areNotEqual(null, ctrl.name, 'Control name should not be null');
             Assert.areNotEqual(null, ctrl.severity, 'Control severity should not be null');
         }
-        System.assert(categories.contains('Administrative'), 'Should include Administrative safeguards');
-        System.assert(categories.contains('Physical'), 'Should include Physical safeguards');
-        System.assert(categories.contains('Technical'), 'Should include Technical safeguards');
+        Assert.isTrue(categories.contains('Administrative'), 'Should include Administrative safeguards');
+        Assert.isTrue(categories.contains('Physical'), 'Should include Physical safeguards');
+        Assert.isTrue(categories.contains('Technical'), 'Should include Technical safeguards');
     }
 
     // =============================================
@@ -119,7 +119,7 @@ private class HIPAAModuleTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, score, 'Score should not be null');
-        System.assert(score >= 0, 'Score should be >= 0');
+        Assert.isTrue(score >= 0, 'Score should be >= 0');
     }
 
     @IsTest
@@ -236,7 +236,7 @@ private class HIPAAModuleTest {
         Assert.areEqual('164.312(a)', result.controlId, 'Control ID should match');
         Assert.areNotEqual(null, result.status, 'Status should not be null');
         Assert.areNotEqual(null, result.finding, 'Finding should not be null');
-        System.assert(result.score >= 0 && result.score <= 100, 'Score should be between 0 and 100');
+        Assert.isTrue(result.score >= 0 && result.score <= 100, 'Score should be between 0 and 100');
     }
 
     @IsTest
@@ -269,7 +269,7 @@ private class HIPAAModuleTest {
 
         Assert.areNotEqual(null, result, 'Result should not be null');
         Assert.areEqual('164.312(d)', result.controlId, 'Control ID should match');
-        System.assert(result.passed, 'Authentication control should pass by default');
+        Assert.isTrue(result.passed, 'Authentication control should pass by default');
         Assert.areEqual(85, result.score, 'Score should be 85');
     }
 
@@ -287,7 +287,7 @@ private class HIPAAModuleTest {
 
         Assert.areNotEqual(null, result, 'Result should not be null');
         Assert.areEqual('164.312(e)', result.controlId, 'Control ID should match');
-        System.assert(result.passed, 'Transmission security should pass (TLS enforced)');
+        Assert.isTrue(result.passed, 'Transmission security should pass (TLS enforced)');
         Assert.areEqual(100, result.score, 'Score should be 100');
         Assert.areEqual('COMPLIANT', result.status, 'Status should be COMPLIANT');
     }
@@ -306,7 +306,7 @@ private class HIPAAModuleTest {
 
         Assert.areNotEqual(null, result, 'Result should not be null');
         Assert.areEqual('164.308(a)(6)', result.controlId, 'Control ID should match');
-        System.assert(result.passed, 'Incident procedures should pass');
+        Assert.isTrue(result.passed, 'Incident procedures should pass');
     }
 
     @IsTest
@@ -368,11 +368,11 @@ private class HIPAAModuleTest {
 
         Assert.areNotEqual(null, gaps, 'Gaps list should not be null');
         // Without evidence, more gaps should be identified
-        System.assert(gaps.size() > 0, 'Should identify gaps when no evidence is present');
+        Assert.isTrue(gaps.size() > 0, 'Should identify gaps when no evidence is present');
 
         // Verify gap properties
         for (IComplianceModule.Gap gap : gaps) {
-            System.assert(gap.id.startsWith('GAP-'), 'Gap ID should start with GAP-');
+            Assert.isTrue(gap.id.startsWith('GAP-'), 'Gap ID should start with GAP-');
             Assert.areNotEqual(null, gap.description, 'Gap description should not be null');
             Assert.areNotEqual(null, gap.riskScore, 'Gap risk score should not be null');
         }
@@ -400,7 +400,7 @@ private class HIPAAModuleTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, score, 'Score should not be null even without evidence');
-        System.assert(score >= 0, 'Score should be non-negative');
+        Assert.isTrue(score >= 0, 'Score should be non-negative');
     }
 
     // =============================================
@@ -427,7 +427,7 @@ private class HIPAAModuleTest {
         Test.startTest();
         for (Elaro_Audit_Package__c pkg : packages) {
             Decimal score = module.calculateScore(pkg.Id);
-            System.assert(score >= 0, 'Score should be non-negative for package: ' + pkg.Id);
+            Assert.isTrue(score >= 0, 'Score should be non-negative for package: ' + pkg.Id);
 
             List<IComplianceModule.Gap> gaps = module.identifyGaps(pkg.Id);
             Assert.areNotEqual(null, gaps, 'Gaps should not be null for package: ' + pkg.Id);

--- a/force-app/main/default/classes/HIPAAPrivacyRuleServiceTest.cls
+++ b/force-app/main/default/classes/HIPAAPrivacyRuleServiceTest.cls
@@ -63,7 +63,7 @@ public class HIPAAPrivacyRuleServiceTest {
         Decimal score = service.getComplianceScore();
         Test.stopTest();
 
-        System.assert(score >= 0 && score <= 100, 'Score should be between 0 and 100');
+        Assert.isTrue(score >= 0 && score <= 100, 'Score should be between 0 and 100');
     }
 
     @isTest
@@ -74,7 +74,7 @@ public class HIPAAPrivacyRuleServiceTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, phiObjects, 'PHI objects list should not be null');
-        System.assert(phiObjects.size() > 0, 'Should identify at least one PHI object');
+        Assert.isTrue(phiObjects.size() > 0, 'Should identify at least one PHI object');
     }
 
     @isTest
@@ -121,7 +121,7 @@ public class HIPAAPrivacyRuleServiceTest {
         Assert.areNotEqual(null, docId, 'Document ID should not be null');
 
         ContentDocument doc = [SELECT Title FROM ContentDocument WHERE Id = :docId];
-        System.assert(doc.Title.contains('PHI_Disclosure_Log'), 'Title should contain PHI_Disclosure_Log');
+        Assert.isTrue(doc.Title.contains('PHI_Disclosure_Log'), 'Title should contain PHI_Disclosure_Log');
     }
 
     @isTest
@@ -167,6 +167,6 @@ public class HIPAAPrivacyRuleServiceTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, violations, 'Violations should not be null');
-        System.assert(score >= 0, 'Score should be non-negative');
+        Assert.isTrue(score >= 0, 'Score should be non-negative');
     }
 }

--- a/force-app/main/default/classes/HIPAASecurityRuleServiceTest.cls
+++ b/force-app/main/default/classes/HIPAASecurityRuleServiceTest.cls
@@ -53,7 +53,7 @@ public class HIPAASecurityRuleServiceTest {
         Decimal score = service.getComplianceScore();
         Test.stopTest();
 
-        System.assert(score >= 0 && score <= 100, 'Score should be between 0 and 100');
+        Assert.isTrue(score >= 0 && score <= 100, 'Score should be between 0 and 100');
     }
 
     @isTest
@@ -127,10 +127,10 @@ public class HIPAASecurityRuleServiceTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, status, 'Status should not be null');
-        System.assert(status.containsKey('Contact'), 'Should include Contact object');
-        System.assert(status.containsKey('Lead'), 'Should include Lead object');
-        System.assert(status.containsKey('Account'), 'Should include Account object');
-        System.assert(status.containsKey('Case'), 'Should include Case object');
+        Assert.isTrue(status.containsKey('Contact'), 'Should include Contact object');
+        Assert.isTrue(status.containsKey('Lead'), 'Should include Lead object');
+        Assert.isTrue(status.containsKey('Account'), 'Should include Account object');
+        Assert.isTrue(status.containsKey('Case'), 'Should include Case object');
     }
 
     @isTest
@@ -155,7 +155,7 @@ public class HIPAASecurityRuleServiceTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, result.overallScore, 'Overall score should be set');
-        System.assert(result.overallScore >= 0 && result.overallScore <= 100,
+        Assert.isTrue(result.overallScore >= 0 && result.overallScore <= 100,
             'Overall score should be between 0 and 100');
         Assert.areNotEqual(null, result.overallCompliant, 'Overall compliant flag should be set');
         Assert.areNotEqual(null, result.gaps, 'Gaps list should not be null');

--- a/force-app/main/default/classes/JiraIntegrationServiceTest.cls
+++ b/force-app/main/default/classes/JiraIntegrationServiceTest.cls
@@ -100,7 +100,7 @@ private class JiraIntegrationServiceTest {
             JiraIntegrationService.createIssue(gap.Id, null);
             Assert.fail( 'Should have thrown exception');
         } catch (JiraIntegrationService.JiraIntegrationException e) {
-            System.assert(e.getMessage().contains('already exists'), 'Should mention existing issue');
+            Assert.isTrue(e.getMessage().contains('already exists'), 'Should mention existing issue');
         }
         Test.stopTest();
     }
@@ -116,7 +116,7 @@ private class JiraIntegrationServiceTest {
             JiraIntegrationService.createIssue(gap.Id, null);
             Assert.fail( 'Should have thrown exception');
         } catch (JiraIntegrationService.JiraIntegrationException e) {
-            System.assert(e.getMessage().contains('Failed'), 'Should indicate failure');
+            Assert.isTrue(e.getMessage().contains('Failed'), 'Should indicate failure');
         }
         Test.stopTest();
     }
@@ -128,7 +128,7 @@ private class JiraIntegrationServiceTest {
             JiraIntegrationService.createIssue('001000000000000AAA', null);
             Assert.fail( 'Should have thrown exception');
         } catch (JiraIntegrationService.JiraIntegrationException e) {
-            System.assert(e.getMessage().contains('not found'), 'Should indicate not found');
+            Assert.isTrue(e.getMessage().contains('not found'), 'Should indicate not found');
         }
         Test.stopTest();
     }
@@ -173,7 +173,7 @@ private class JiraIntegrationServiceTest {
             JiraIntegrationService.getIssueStatus('INVALID-999');
             Assert.fail( 'Should have thrown exception');
         } catch (JiraIntegrationService.JiraIntegrationException e) {
-            System.assert(e.getMessage().contains('not found'), 'Should indicate not found');
+            Assert.isTrue(e.getMessage().contains('not found'), 'Should indicate not found');
         }
         Test.stopTest();
     }
@@ -185,7 +185,7 @@ private class JiraIntegrationServiceTest {
             JiraIntegrationService.getIssueStatus('');
             Assert.fail( 'Should have thrown exception');
         } catch (JiraIntegrationService.JiraIntegrationException e) {
-            System.assert(e.getMessage().contains('required'), 'Should indicate key required');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should indicate key required');
         }
         Test.stopTest();
     }
@@ -218,7 +218,7 @@ private class JiraIntegrationServiceTest {
             JiraIntegrationService.syncIssueStatus(gap.Id);
             Assert.fail( 'Should have thrown exception');
         } catch (JiraIntegrationService.JiraIntegrationException e) {
-            System.assert(e.getMessage().contains('No Jira issue'), 'Should indicate no link');
+            Assert.isTrue(e.getMessage().contains('No Jira issue'), 'Should indicate no link');
         }
         Test.stopTest();
     }
@@ -279,7 +279,7 @@ private class JiraIntegrationServiceTest {
             JiraIntegrationService.addComment('', '');
             Assert.fail( 'Should have thrown exception');
         } catch (JiraIntegrationService.JiraIntegrationException e) {
-            System.assert(e.getMessage().contains('required'), 'Should indicate required params');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should indicate required params');
         }
         Test.stopTest();
     }
@@ -297,7 +297,7 @@ private class JiraIntegrationServiceTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, transitions, 'Should return transitions');
-        System.assert(transitions.size() > 0, 'Should have at least one transition');
+        Assert.isTrue(transitions.size() > 0, 'Should have at least one transition');
     }
 
     @isTest

--- a/force-app/main/default/classes/JiraWebhookHandlerTest.cls
+++ b/force-app/main/default/classes/JiraWebhookHandlerTest.cls
@@ -227,8 +227,8 @@ private class JiraWebhookHandlerTest {
 
         // Verify comment was added to notes
         Compliance_Gap__c updatedGap = [SELECT Notes__c FROM Compliance_Gap__c WHERE Jira_Issue_Key__c = :MOCK_JIRA_KEY];
-        System.assert(updatedGap.Notes__c.contains('This is a test comment'), 'Notes should contain comment');
-        System.assert(updatedGap.Notes__c.contains('John Doe'), 'Notes should contain author');
+        Assert.isTrue(updatedGap.Notes__c.contains('This is a test comment'), 'Notes should contain comment');
+        Assert.isTrue(updatedGap.Notes__c.contains('John Doe'), 'Notes should contain author');
     }
 
     @isTest

--- a/force-app/main/default/classes/LimitMetricsTest.cls
+++ b/force-app/main/default/classes/LimitMetricsTest.cls
@@ -11,16 +11,16 @@ private class LimitMetricsTest {
 
         // Verify all fields are populated with valid values
         Assert.areNotEqual(null, g.cpuMs, 'CPU time should not be null');
-        System.assert(g.cpuMs >= 0, 'CPU time should be non-negative');
+        Assert.isTrue(g.cpuMs >= 0, 'CPU time should be non-negative');
 
         Assert.areNotEqual(null, g.soql, 'SOQL queries should not be null');
-        System.assert(g.soql >= 0, 'SOQL queries should be non-negative');
+        Assert.isTrue(g.soql >= 0, 'SOQL queries should be non-negative');
 
         Assert.areNotEqual(null, g.dml, 'DML statements should not be null');
-        System.assert(g.dml >= 0, 'DML statements should be non-negative');
+        Assert.isTrue(g.dml >= 0, 'DML statements should be non-negative');
 
         Assert.areNotEqual(null, g.heapKb, 'Heap size should not be null');
-        System.assert(g.heapKb >= 0, 'Heap size should be non-negative');
+        Assert.isTrue(g.heapKb >= 0, 'Heap size should be non-negative');
     }
 
     @IsTest
@@ -37,8 +37,8 @@ private class LimitMetricsTest {
         Test.stopTest();
 
         // Verify limits show usage (DML includes the insert above)
-        System.assert(g.dml >= 0, 'DML count should be non-negative');
-        System.assert(g.heapKb >= 0, 'Heap should be non-negative');
+        Assert.isTrue(g.dml >= 0, 'DML count should be non-negative');
+        Assert.isTrue(g.heapKb >= 0, 'Heap should be non-negative');
     }
 
     @IsTest
@@ -56,7 +56,7 @@ private class LimitMetricsTest {
 
         // Verify method works and returns valid stats
         Assert.areNotEqual(null, g, 'GovernorStats should be returned');
-        System.assert(g.soql >= 0, 'SOQL count should be valid');
+        Assert.isTrue(g.soql >= 0, 'SOQL count should be valid');
     }
 
     @IsTest

--- a/force-app/main/default/classes/MetadataChangeTrackerTest.cls
+++ b/force-app/main/default/classes/MetadataChangeTrackerTest.cls
@@ -62,6 +62,6 @@ private class MetadataChangeTrackerTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, recentChanges, 'Recent changes should not be null');
-        System.assert(!recentChanges.isEmpty(), 'Should have recent changes');
+        Assert.isTrue(!recentChanges.isEmpty(), 'Should have recent changes');
     }
 }

--- a/force-app/main/default/classes/MobileAlertPublisherTest.cls
+++ b/force-app/main/default/classes/MobileAlertPublisherTest.cls
@@ -165,7 +165,7 @@ private class MobileAlertPublisherTest {
             MobileAlertPublisher.publishAlertForGap('001000000000000AAA');
             Assert.fail( 'Expected exception for invalid gap ID');
         } catch (MobileAlertPublisher.MobileAlertException e) {
-            System.assert(e.getMessage().contains('not found'), 'Expected not found error');
+            Assert.isTrue(e.getMessage().contains('not found'), 'Expected not found error');
         }
         Test.stopTest();
     }
@@ -206,7 +206,7 @@ private class MobileAlertPublisherTest {
         ];
 
         Assert.areNotEqual(null, updatedGap.Alert_Snoozed_Until__c, 'Snoozed until should be set');
-        System.assert(updatedGap.Alert_Snoozed_Until__c > Datetime.now(), 'Snoozed until should be in the future');
+        Assert.isTrue(updatedGap.Alert_Snoozed_Until__c > Datetime.now(), 'Snoozed until should be in the future');
     }
 
     @isTest
@@ -218,7 +218,7 @@ private class MobileAlertPublisherTest {
             MobileAlertPublisher.snoozeAlert(gap.Id, 0);
             Assert.fail( 'Expected exception for zero duration');
         } catch (MobileAlertPublisher.MobileAlertException e) {
-            System.assert(e.getMessage().contains('between 1 and 480'), 'Expected duration validation error');
+            Assert.isTrue(e.getMessage().contains('between 1 and 480'), 'Expected duration validation error');
         }
         Test.stopTest();
     }
@@ -232,7 +232,7 @@ private class MobileAlertPublisherTest {
             MobileAlertPublisher.snoozeAlert(gap.Id, 500);
             Assert.fail( 'Expected exception for duration > 480');
         } catch (MobileAlertPublisher.MobileAlertException e) {
-            System.assert(e.getMessage().contains('between 1 and 480'), 'Expected duration validation error');
+            Assert.isTrue(e.getMessage().contains('between 1 and 480'), 'Expected duration validation error');
         }
         Test.stopTest();
     }
@@ -246,7 +246,7 @@ private class MobileAlertPublisherTest {
             MobileAlertPublisher.snoozeAlert(gap.Id, -10);
             Assert.fail( 'Expected exception for negative duration');
         } catch (MobileAlertPublisher.MobileAlertException e) {
-            System.assert(e.getMessage().contains('between 1 and 480'), 'Expected duration validation error');
+            Assert.isTrue(e.getMessage().contains('between 1 and 480'), 'Expected duration validation error');
         }
         Test.stopTest();
     }

--- a/force-app/main/default/classes/MultiOrgManagerTest.cls
+++ b/force-app/main/default/classes/MultiOrgManagerTest.cls
@@ -76,7 +76,7 @@ private class MultiOrgManagerTest {
             MultiOrgManager.registerOrg(orgConfig);
             Assert.fail( 'Should throw exception for missing name');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('name'), 'Should mention name requirement');
+            Assert.isTrue(e.getMessage().contains('name'), 'Should mention name requirement');
         }
         Test.stopTest();
     }
@@ -93,7 +93,7 @@ private class MultiOrgManagerTest {
             MultiOrgManager.registerOrg(orgConfig);
             Assert.fail( 'Should throw exception for missing org ID');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Org ID'), 'Should mention org ID requirement');
+            Assert.isTrue(e.getMessage().contains('Org ID'), 'Should mention org ID requirement');
         }
         Test.stopTest();
     }
@@ -110,7 +110,7 @@ private class MultiOrgManagerTest {
             MultiOrgManager.registerOrg(orgConfig);
             Assert.fail( 'Should throw exception for missing instance URL');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Instance URL'), 'Should mention instance URL requirement');
+            Assert.isTrue(e.getMessage().contains('Instance URL'), 'Should mention instance URL requirement');
         }
         Test.stopTest();
     }
@@ -128,8 +128,8 @@ private class MultiOrgManagerTest {
         Assert.areNotEqual(null, status, 'Should return status');
         Assert.areNotEqual(null, status.currentOrg, 'Should have current org');
         Assert.areNotEqual(null, status.connectedOrgs, 'Should have connected orgs list');
-        System.assert(status.totalOrgs > 0, 'Should have at least one org');
-        System.assert(status.aggregateScore >= 0, 'Aggregate score should be non-negative');
+        Assert.isTrue(status.totalOrgs > 0, 'Should have at least one org');
+        Assert.isTrue(status.aggregateScore >= 0, 'Aggregate score should be non-negative');
     }
     
     @isTest
@@ -139,7 +139,7 @@ private class MultiOrgManagerTest {
         MultiOrgManager.MultiOrgStatus status = MultiOrgManager.getMultiOrgStatus();
         Test.stopTest();
         
-        System.assert(status.connectedOrgs.size() >= 5, 'Should include test connected orgs');
+        Assert.isTrue(status.connectedOrgs.size() >= 5, 'Should include test connected orgs');
         
         // Verify org details
         for (MultiOrgManager.OrgStatus os : status.connectedOrgs) {
@@ -239,10 +239,10 @@ private class MultiOrgManagerTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, metrics, 'Should return metrics');
-        System.assert(metrics.totalEvents >= 0, 'Total events should be non-negative');
-        System.assert(metrics.totalAlerts >= 0, 'Total alerts should be non-negative');
-        System.assert(metrics.avgComplianceScore >= 0, 'Average score should be non-negative');
-        System.assert(metrics.orgCount > 0, 'Should have at least one org');
+        Assert.isTrue(metrics.totalEvents >= 0, 'Total events should be non-negative');
+        Assert.isTrue(metrics.totalAlerts >= 0, 'Total alerts should be non-negative');
+        Assert.isTrue(metrics.avgComplianceScore >= 0, 'Average score should be non-negative');
+        Assert.isTrue(metrics.orgCount > 0, 'Should have at least one org');
     }
     
     @isTest
@@ -253,7 +253,7 @@ private class MultiOrgManagerTest {
         Test.stopTest();
         
         // Should include evidence items from test setup
-        System.assert(metrics.totalEvents >= 10, 'Should count evidence items');
+        Assert.isTrue(metrics.totalEvents >= 10, 'Should count evidence items');
     }
     
     // ═══════════════════════════════════════════════════════════════

--- a/force-app/main/default/classes/NaturalLanguageQueryServiceTest.cls
+++ b/force-app/main/default/classes/NaturalLanguageQueryServiceTest.cls
@@ -27,7 +27,7 @@ private class NaturalLanguageQueryServiceTest {
         Assert.areNotEqual(null, result, 'Should return result');
         Assert.areNotEqual(null, result.generatedSOQL, 'Should have generated SOQL');
         Assert.areNotEqual(null, result.results, 'Should have results list');
-        System.assert(result.confidence &gt;= 0, 'Should have confidence score');
+        Assert.isTrue(result.confidence &gt;= 0, 'Should have confidence score');
     }
     
     @isTest
@@ -39,7 +39,7 @@ private class NaturalLanguageQueryServiceTest {
             NaturalLanguageQueryService.executeNaturalLanguageQuery('');
             Assert.fail( 'Should throw exception');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should mention required');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should mention required');
         }
         Test.stopTest();
     }
@@ -53,7 +53,7 @@ private class NaturalLanguageQueryServiceTest {
             NaturalLanguageQueryService.executeNaturalLanguageQuery(null);
             Assert.fail( 'Should throw exception');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should mention required');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should mention required');
         }
         Test.stopTest();
     }
@@ -80,7 +80,7 @@ private class NaturalLanguageQueryServiceTest {
         List&lt;String&gt; suggestions = NaturalLanguageQueryService.getQuerySuggestions('');
         Test.stopTest();
         
-        System.assert(!suggestions.isEmpty(), 'Should return example suggestions');
+        Assert.isTrue(!suggestions.isEmpty(), 'Should return example suggestions');
     }
     
     @isTest
@@ -89,7 +89,7 @@ private class NaturalLanguageQueryServiceTest {
         List&lt;String&gt; suggestions = NaturalLanguageQueryService.getQuerySuggestions(null);
         Test.stopTest();
         
-        System.assert(!suggestions.isEmpty(), 'Should return example suggestions for null');
+        Assert.isTrue(!suggestions.isEmpty(), 'Should return example suggestions for null');
     }
     
     @isTest
@@ -106,7 +106,7 @@ private class NaturalLanguageQueryServiceTest {
                 break;
             }
         }
-        System.assert(hasAdminSuggestion, 'Should include admin-related suggestions');
+        Assert.isTrue(hasAdminSuggestion, 'Should include admin-related suggestions');
     }
     
     @isTest
@@ -115,7 +115,7 @@ private class NaturalLanguageQueryServiceTest {
         List&lt;String&gt; suggestions = NaturalLanguageQueryService.getQuerySuggestions('export');
         Test.stopTest();
         
-        System.assert(!suggestions.isEmpty(), 'Should return export-related suggestions');
+        Assert.isTrue(!suggestions.isEmpty(), 'Should return export-related suggestions');
     }
     
     // ═══════════════════════════════════════════════════════════════
@@ -146,7 +146,7 @@ private class NaturalLanguageQueryServiceTest {
         Test.stopTest();
         
         Assert.areEqual(false, result.isValid, 'Should be invalid');
-        System.assert(result.message.contains('empty'), 'Should mention empty');
+        Assert.isTrue(result.message.contains('empty'), 'Should mention empty');
     }
     
     @isTest

--- a/force-app/main/default/classes/OnCallScheduleControllerTest.cls
+++ b/force-app/main/default/classes/OnCallScheduleControllerTest.cls
@@ -113,7 +113,7 @@ private class OnCallScheduleControllerTest {
             OnCallScheduleController.createSchedule(schedule);
             Assert.fail( 'Expected exception for missing start time');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Start time'), 'Error message should mention start time');
+            Assert.isTrue(e.getMessage().contains('Start time'), 'Error message should mention start time');
         }
         Test.stopTest();
     }
@@ -135,7 +135,7 @@ private class OnCallScheduleControllerTest {
             OnCallScheduleController.createSchedule(schedule);
             Assert.fail( 'Expected exception for missing end time');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('End time'), 'Error message should mention end time');
+            Assert.isTrue(e.getMessage().contains('End time'), 'Error message should mention end time');
         }
         Test.stopTest();
     }
@@ -157,7 +157,7 @@ private class OnCallScheduleControllerTest {
             OnCallScheduleController.createSchedule(schedule);
             Assert.fail( 'Expected exception for invalid time range');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('after start'), 'Error message should mention time order');
+            Assert.isTrue(e.getMessage().contains('after start'), 'Error message should mention time order');
         }
         Test.stopTest();
     }
@@ -177,7 +177,7 @@ private class OnCallScheduleControllerTest {
             OnCallScheduleController.createSchedule(schedule);
             Assert.fail( 'Expected exception for missing user');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('User'), 'Error message should mention user');
+            Assert.isTrue(e.getMessage().contains('User'), 'Error message should mention user');
         }
         Test.stopTest();
     }

--- a/force-app/main/default/classes/PCIAccessControlServiceTest.cls
+++ b/force-app/main/default/classes/PCIAccessControlServiceTest.cls
@@ -42,7 +42,7 @@ private class PCIAccessControlServiceTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, result, 'RBAC result should not be null');
-        System.assert(result.containsKey('hasAccess'), 'Should include access decision');
+        Assert.isTrue(result.containsKey('hasAccess'), 'Should include access decision');
     }
     
     @IsTest
@@ -62,7 +62,7 @@ private class PCIAccessControlServiceTest {
         }
         Test.stopTest();
         
-        System.assert(results.size() > 0, 'Should process bulk RBAC checks');
+        Assert.isTrue(results.size() > 0, 'Should process bulk RBAC checks');
     }
     
     @IsTest
@@ -111,7 +111,7 @@ private class PCIAccessControlServiceTest {
             service.enforceRBAC(null, 'Resource');
             Assert.fail( 'Should throw exception for null user');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should validate required parameters');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should validate required parameters');
         }
         Test.stopTest();
     }
@@ -124,7 +124,7 @@ private class PCIAccessControlServiceTest {
             service.rotateCredentials(null);
             Assert.fail( 'Should throw exception for null user');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should validate required parameters');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should validate required parameters');
         }
         Test.stopTest();
     }

--- a/force-app/main/default/classes/PCIDataProtectionServiceTest.cls
+++ b/force-app/main/default/classes/PCIDataProtectionServiceTest.cls
@@ -41,7 +41,7 @@ private class PCIDataProtectionServiceTest {
         }
         Test.stopTest();
         
-        System.assert(encryptedDataList.size() > 0, 'Should process bulk encryption');
+        Assert.isTrue(encryptedDataList.size() > 0, 'Should process bulk encryption');
     }
     
     @IsTest
@@ -55,7 +55,7 @@ private class PCIDataProtectionServiceTest {
         
         Assert.areNotEqual(null, token, 'Token should not be null');
         Assert.areNotEqual(cardholderData, token, 'Token should differ from original');
-        System.assert(token.startsWith('TOKEN-'), 'Token should have TOKEN prefix');
+        Assert.isTrue(token.startsWith('TOKEN-'), 'Token should have TOKEN prefix');
     }
     
     @IsTest
@@ -78,7 +78,7 @@ private class PCIDataProtectionServiceTest {
         }
         Test.stopTest();
         
-        System.assert(tokens.size() > 0, 'Should process bulk tokenization');
+        Assert.isTrue(tokens.size() > 0, 'Should process bulk tokenization');
     }
     
     @IsTest
@@ -93,7 +93,7 @@ private class PCIDataProtectionServiceTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, result, 'Validation result should not be null');
-        System.assert(result.containsKey('isValid'), 'Should include validation status');
+        Assert.isTrue(result.containsKey('isValid'), 'Should include validation status');
     }
     
     @IsTest
@@ -156,7 +156,7 @@ private class PCIDataProtectionServiceTest {
             service.encryptCHD(null);
             Assert.fail( 'Should throw exception for null data');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should validate required parameters');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should validate required parameters');
         }
         Test.stopTest();
     }
@@ -169,7 +169,7 @@ private class PCIDataProtectionServiceTest {
             service.tokenizeData(null);
             Assert.fail( 'Should throw exception for null data');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should validate required parameters');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should validate required parameters');
         }
         Test.stopTest();
     }
@@ -182,7 +182,7 @@ private class PCIDataProtectionServiceTest {
             service.validateEncryption(null);
             Assert.fail( 'Should throw exception for null data');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should validate required parameters');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should validate required parameters');
         }
         Test.stopTest();
     }
@@ -195,7 +195,7 @@ private class PCIDataProtectionServiceTest {
             service.keyManagement(null, null);
             Assert.fail( 'Should throw exception for null operation');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should validate required parameters');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should validate required parameters');
         }
         Test.stopTest();
     }

--- a/force-app/main/default/classes/PCILoggingServiceTest.cls
+++ b/force-app/main/default/classes/PCILoggingServiceTest.cls
@@ -65,7 +65,7 @@ private class PCILoggingServiceTest {
         }
         Test.stopTest();
         
-        System.assert(logIds.size() > 0, 'Should process bulk log events');
+        Assert.isTrue(logIds.size() > 0, 'Should process bulk log events');
     }
     
     @IsTest
@@ -76,8 +76,8 @@ private class PCILoggingServiceTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, result, 'Integrity check result should not be null');
-        System.assert(result.containsKey('integrityCheck'), 'Should include integrity check status');
-        System.assert(result.containsKey('logsChecked'), 'Should include logs checked count');
+        Assert.isTrue(result.containsKey('integrityCheck'), 'Should include integrity check status');
+        Assert.isTrue(result.containsKey('logsChecked'), 'Should include logs checked count');
     }
     
     @IsTest
@@ -108,7 +108,7 @@ private class PCILoggingServiceTest {
         Test.stopTest();
         
         Assert.areEqual(true, result.get('success'), 'Log archiving should succeed');
-        System.assert(result.containsKey('logsArchived'), 'Should include archived count');
+        Assert.isTrue(result.containsKey('logsArchived'), 'Should include archived count');
     }
     
     @IsTest
@@ -119,7 +119,7 @@ private class PCILoggingServiceTest {
             service.logSecurityEvent(null, null, null, null);
             Assert.fail( 'Should throw exception for null parameters');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should validate required parameters');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should validate required parameters');
         }
         Test.stopTest();
     }
@@ -132,7 +132,7 @@ private class PCILoggingServiceTest {
             service.alertOnAnomaly(null, new Map<String, Object>());
             Assert.fail( 'Should throw exception for null anomaly type');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should validate required parameters');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should validate required parameters');
         }
         Test.stopTest();
     }
@@ -145,7 +145,7 @@ private class PCILoggingServiceTest {
             service.archiveLogs(null);
             Assert.fail( 'Should throw exception for null retention days');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should validate required parameters');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should validate required parameters');
         }
         Test.stopTest();
     }

--- a/force-app/main/default/classes/PagerDutyIntegrationTest.cls
+++ b/force-app/main/default/classes/PagerDutyIntegrationTest.cls
@@ -172,7 +172,7 @@ private class PagerDutyIntegrationTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, dedupKey, 'Should return dedup key');
-        System.assert(dedupKey.startsWith('elaro-'), 'Dedup key should start with elaro-');
+        Assert.isTrue(dedupKey.startsWith('elaro-'), 'Dedup key should start with elaro-');
     }
     
     @isTest
@@ -274,7 +274,7 @@ private class PagerDutyIntegrationTest {
 
         // Verify bulk operations completed within governor limits
         Assert.areEqual(200, alertDataList.size(), 'Should process 200 incidents');
-        System.assert(Limits.getCallouts() <= Limits.getLimitCallouts(), 'Should stay within callout limits');
+        Assert.isTrue(Limits.getCallouts() <= Limits.getLimitCallouts(), 'Should stay within callout limits');
     }
     
     // ═══════════════════════════════════════════════════════════════

--- a/force-app/main/default/classes/PerformanceAlertPublisherTest.cls
+++ b/force-app/main/default/classes/PerformanceAlertPublisherTest.cls
@@ -29,10 +29,10 @@ private class PerformanceAlertPublisherTest {
             PerformanceAlertPublisher.publish(null, 8500, 10000, null, null);
         } catch (AuraHandledException e) {
             exceptionThrown = true;
-            System.assert(e.getMessage().contains('Metric cannot be blank'), 'Expected validation error');
+            Assert.isTrue(e.getMessage().contains('Metric cannot be blank'), 'Expected validation error');
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Expected AuraHandledException to be thrown');
+        Assert.isTrue(exceptionThrown, 'Expected AuraHandledException to be thrown');
     }
 
     @isTest
@@ -43,10 +43,10 @@ private class PerformanceAlertPublisherTest {
             PerformanceAlertPublisher.publish('', 8500, 10000, null, null);
         } catch (AuraHandledException e) {
             exceptionThrown = true;
-            System.assert(e.getMessage().contains('Metric cannot be blank'), 'Expected validation error');
+            Assert.isTrue(e.getMessage().contains('Metric cannot be blank'), 'Expected validation error');
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Expected AuraHandledException to be thrown');
+        Assert.isTrue(exceptionThrown, 'Expected AuraHandledException to be thrown');
     }
 
     @isTest
@@ -57,10 +57,10 @@ private class PerformanceAlertPublisherTest {
             PerformanceAlertPublisher.publish('CPU', null, 10000, null, null);
         } catch (AuraHandledException e) {
             exceptionThrown = true;
-            System.assert(e.getMessage().contains('Value cannot be null'), 'Expected validation error');
+            Assert.isTrue(e.getMessage().contains('Value cannot be null'), 'Expected validation error');
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Expected AuraHandledException to be thrown');
+        Assert.isTrue(exceptionThrown, 'Expected AuraHandledException to be thrown');
     }
 
     @isTest
@@ -71,10 +71,10 @@ private class PerformanceAlertPublisherTest {
             PerformanceAlertPublisher.publish('CPU', 8500, null, null, null);
         } catch (AuraHandledException e) {
             exceptionThrown = true;
-            System.assert(e.getMessage().contains('Threshold cannot be null'), 'Expected validation error');
+            Assert.isTrue(e.getMessage().contains('Threshold cannot be null'), 'Expected validation error');
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Expected AuraHandledException to be thrown');
+        Assert.isTrue(exceptionThrown, 'Expected AuraHandledException to be thrown');
     }
 
     @isTest
@@ -94,7 +94,7 @@ private class PerformanceAlertPublisherTest {
             WHERE Metric__c = 'HEAP'
         ];
         Assert.areEqual(1, alerts.size(), 'Expected one alert to be saved');
-        System.assert(alerts[0].Stack__c.length() <= 32768, 'Stack should be truncated');
+        Assert.isTrue(alerts[0].Stack__c.length() <= 32768, 'Stack should be truncated');
     }
 
     @isTest
@@ -116,7 +116,7 @@ private class PerformanceAlertPublisherTest {
         ];
         Assert.areEqual(1, alerts.size(), 'Expected one alert to be saved');
         // Stack should be truncated to 32768 (32765 + '...')
-        System.assert(alerts[0].Stack__c.endsWith('...'), 'Stack should end with ellipsis when truncated');
+        Assert.isTrue(alerts[0].Stack__c.endsWith('...'), 'Stack should end with ellipsis when truncated');
     }
 
     @isTest
@@ -134,9 +134,9 @@ private class PerformanceAlertPublisherTest {
         ];
         Assert.areEqual(1, alerts.size(), 'Expected one alert to be saved');
         // Verify XSS characters are escaped
-        System.assert(!alerts[0].Stack__c.contains('<script>'), 'Script tags should be escaped');
-        System.assert(alerts[0].Stack__c.contains('&lt;'), 'Less than should be escaped');
-        System.assert(alerts[0].Stack__c.contains('&gt;'), 'Greater than should be escaped');
+        Assert.isTrue(!alerts[0].Stack__c.contains('<script>'), 'Script tags should be escaped');
+        Assert.isTrue(alerts[0].Stack__c.contains('&lt;'), 'Less than should be escaped');
+        Assert.isTrue(alerts[0].Stack__c.contains('&gt;'), 'Greater than should be escaped');
     }
 
     @isTest
@@ -271,10 +271,10 @@ private class PerformanceAlertPublisherTest {
             PerformanceAlertPublisher.publish('   ', 8500, 10000, null, null);
         } catch (AuraHandledException e) {
             exceptionThrown = true;
-            System.assert(e.getMessage().contains('Metric cannot be blank'), 'Expected validation error');
+            Assert.isTrue(e.getMessage().contains('Metric cannot be blank'), 'Expected validation error');
         }
         Test.stopTest();
-        System.assert(exceptionThrown, 'Expected AuraHandledException for whitespace metric');
+        Assert.isTrue(exceptionThrown, 'Expected AuraHandledException for whitespace metric');
     }
 
     @isTest
@@ -301,9 +301,9 @@ private class PerformanceAlertPublisherTest {
         Assert.areEqual(200, alerts.size(), 'Should save all 200 alerts');
 
         // Verify governor limits were not exceeded
-        System.assert(Limits.getQueries() < 100,
+        Assert.isTrue(Limits.getQueries() < 100,
             'SOQL queries should be within limits: ' + Limits.getQueries());
-        System.assert(Limits.getDmlStatements() < 150,
+        Assert.isTrue(Limits.getDmlStatements() < 150,
             'DML statements should be within limits: ' + Limits.getDmlStatements());
     }
 

--- a/force-app/main/default/classes/PerformanceRuleEngineTest.cls
+++ b/force-app/main/default/classes/PerformanceRuleEngineTest.cls
@@ -35,7 +35,7 @@ private class PerformanceRuleEngineTest {
         
         Assert.areEqual(true, result.warning, 'Should trigger warning');
         Assert.areEqual(false, result.critical, 'Should not trigger critical');
-        System.assert(result.eventsPublished > 0, 'Should have published events');
+        Assert.isTrue(result.eventsPublished > 0, 'Should have published events');
     }
     
     @isTest
@@ -51,7 +51,7 @@ private class PerformanceRuleEngineTest {
         Test.stopTest();
         
         Assert.areEqual(true, result.critical, 'Should trigger critical');
-        System.assert(result.eventsPublished > 0, 'Should have published events');
+        Assert.isTrue(result.eventsPublished > 0, 'Should have published events');
     }
     
     @isTest
@@ -60,7 +60,7 @@ private class PerformanceRuleEngineTest {
         PerformanceRuleEngine.EvalResult result = PerformanceRuleEngine.evaluateAndPublish(null, null);
         Test.stopTest();
         
-        System.assert(result.message.contains('Error'), 'Should return error message');
+        Assert.isTrue(result.message.contains('Error'), 'Should return error message');
     }
     
     @isTest
@@ -77,7 +77,7 @@ private class PerformanceRuleEngineTest {
         
         Assert.areEqual(true, result.critical, 'Should trigger critical');
         Assert.areEqual(true, result.warning, 'Should trigger warning');
-        System.assert(result.eventsPublished >= 4, 'Should have published multiple events');
+        Assert.isTrue(result.eventsPublished >= 4, 'Should have published multiple events');
     }
     
     @isTest
@@ -108,7 +108,7 @@ private class PerformanceRuleEngineTest {
         
         Assert.areEqual(true, result.warning, 'Should trigger warning with custom CPU threshold');
         Assert.areEqual(false, result.critical, 'Should not trigger critical');
-        System.assert(result.eventsPublished > 0, 'Should have published events');
+        Assert.isTrue(result.eventsPublished > 0, 'Should have published events');
     }
     
     @isTest
@@ -125,7 +125,7 @@ private class PerformanceRuleEngineTest {
         
         Assert.areEqual(true, result.warning, 'Should trigger warning for HEAP');
         Assert.areEqual(false, result.critical, 'Should not trigger critical');
-        System.assert(result.eventsPublished > 0, 'Should have published events');
+        Assert.isTrue(result.eventsPublished > 0, 'Should have published events');
     }
     
     @isTest
@@ -142,7 +142,7 @@ private class PerformanceRuleEngineTest {
         
         Assert.areEqual(true, result.warning, 'Should trigger warning for SOQL');
         Assert.areEqual(false, result.critical, 'Should not trigger critical');
-        System.assert(result.eventsPublished > 0, 'Should have published events');
+        Assert.isTrue(result.eventsPublished > 0, 'Should have published events');
     }
     
     @isTest
@@ -159,6 +159,6 @@ private class PerformanceRuleEngineTest {
         
         Assert.areEqual(true, result.warning, 'Should trigger warning for DML');
         Assert.areEqual(false, result.critical, 'Should not trigger critical');
-        System.assert(result.eventsPublished > 0, 'Should have published events');
+        Assert.isTrue(result.eventsPublished > 0, 'Should have published events');
     }
 }

--- a/force-app/main/default/classes/RemediationExecutorTest.cls
+++ b/force-app/main/default/classes/RemediationExecutorTest.cls
@@ -115,7 +115,7 @@ private class RemediationExecutorTest {
         Test.stopTest();
 
         Assert.areEqual(false, result.success, 'Execution should fail');
-        System.assert(result.errorMessage.contains('approved'), 'Error should mention approval');
+        Assert.isTrue(result.errorMessage.contains('approved'), 'Error should mention approval');
     }
 
     @isTest
@@ -131,7 +131,7 @@ private class RemediationExecutorTest {
         Test.stopTest();
 
         Assert.areEqual(false, result.success, 'Execution should fail');
-        System.assert(result.errorMessage.contains('not available'), 'Error should mention auto-remediation not available');
+        Assert.isTrue(result.errorMessage.contains('not available'), 'Error should mention auto-remediation not available');
     }
 
     @isTest
@@ -141,7 +141,7 @@ private class RemediationExecutorTest {
         Test.stopTest();
 
         Assert.areEqual(false, result.success, 'Execution should fail');
-        System.assert(result.errorMessage.contains('not found'), 'Error should mention not found');
+        Assert.isTrue(result.errorMessage.contains('not found'), 'Error should mention not found');
     }
 
     @isTest
@@ -160,7 +160,7 @@ private class RemediationExecutorTest {
         Remediation_Suggestion__c updated = [SELECT Status__c, Applied_At__c, Implementation_Steps__c
                                               FROM Remediation_Suggestion__c WHERE Id = :suggestion.Id];
         Assert.areEqual('APPLIED', updated.Status__c, 'Status should be APPLIED');
-        System.assert(updated.Implementation_Steps__c.contains('Manual Implementation Notes'), 'Notes should be appended');
+        Assert.isTrue(updated.Implementation_Steps__c.contains('Manual Implementation Notes'), 'Notes should be appended');
 
         // Verify gap status
         Compliance_Gap__c gap = [SELECT Status__c, Actual_Remediation_Date__c
@@ -182,7 +182,7 @@ private class RemediationExecutorTest {
             RemediationExecutor.markAsManuallyApplied(suggestion.Id, 'Test notes');
             Assert.fail( 'Expected exception for non-approved suggestion');
         } catch (RemediationSuggestionService.RemediationException e) {
-            System.assert(e.getMessage().contains('approved'), 'Error should mention approval');
+            Assert.isTrue(e.getMessage().contains('approved'), 'Error should mention approval');
         }
         Test.stopTest();
     }
@@ -194,7 +194,7 @@ private class RemediationExecutorTest {
             RemediationExecutor.markAsManuallyApplied('a00000000000000AAA', 'Test notes');
             Assert.fail( 'Expected exception for invalid ID');
         } catch (RemediationSuggestionService.RemediationException e) {
-            System.assert(e.getMessage().contains('not found'), 'Error should mention not found');
+            Assert.isTrue(e.getMessage().contains('not found'), 'Error should mention not found');
         }
         Test.stopTest();
     }
@@ -213,7 +213,7 @@ private class RemediationExecutorTest {
         List<RemediationExecutor.ExecutionHistory> history = RemediationExecutor.getExecutionHistory();
         Test.stopTest();
 
-        System.assert(history.size() > 0, 'Should have execution history');
+        Assert.isTrue(history.size() > 0, 'Should have execution history');
 
         RemediationExecutor.ExecutionHistory item = history[0];
         Assert.areNotEqual(null, item.suggestionId, 'Suggestion ID should be set');
@@ -256,7 +256,7 @@ private class RemediationExecutorTest {
         Test.stopTest();
 
         Assert.areEqual(suggestionIds.size(), result.totalProcessed, 'Total processed should match');
-        System.assert(result.successCount > 0, 'Should have successes');
+        Assert.isTrue(result.successCount > 0, 'Should have successes');
         Assert.areNotEqual(null, result.results, 'Results list should be set');
     }
 
@@ -330,7 +330,7 @@ private class RemediationExecutorTest {
         Test.stopTest();
 
         Assert.areEqual(true, result.success, 'FLS remediation should succeed');
-        System.assert(result.message.contains('Field-level security'), 'Message should mention FLS');
+        Assert.isTrue(result.message.contains('Field-level security'), 'Message should mention FLS');
     }
 
     @isTest
@@ -358,7 +358,7 @@ private class RemediationExecutorTest {
         Test.stopTest();
 
         Assert.areEqual(true, result.success, 'Profile remediation should succeed');
-        System.assert(result.message.contains('Profile update'), 'Message should mention profile');
+        Assert.isTrue(result.message.contains('Profile update'), 'Message should mention profile');
     }
 
     @isTest
@@ -381,7 +381,7 @@ private class RemediationExecutorTest {
         Test.stopTest();
 
         Assert.areEqual(false, result.success, 'Should fail with invalid payload');
-        System.assert(result.errorMessage.contains('Execution failed'), 'Error should mention execution failure');
+        Assert.isTrue(result.errorMessage.contains('Execution failed'), 'Error should mention execution failure');
     }
 
     @isTest

--- a/force-app/main/default/classes/RemediationOrchestratorTest.cls
+++ b/force-app/main/default/classes/RemediationOrchestratorTest.cls
@@ -61,7 +61,7 @@ private class RemediationOrchestratorTest {
             RemediationOrchestrator.createRemediationCase('', 'Medium');
             Assert.fail( 'Should throw exception');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Error message should indicate missing ID');
+            Assert.isTrue(e.getMessage().contains('required'), 'Error message should indicate missing ID');
         }
         Test.stopTest();
     }
@@ -72,15 +72,15 @@ private class RemediationOrchestratorTest {
         List<RemediationOrchestrator.ActionOption> actions = RemediationOrchestrator.getAvailableActions('LoginAs');
         Test.stopTest();
 
-        System.assert(actions.size() >= 2, 'Should have multiple actions available');
+        Assert.isTrue(actions.size() >= 2, 'Should have multiple actions available');
         Boolean hasRevoke = false;
         Boolean hasLock = false;
         for (RemediationOrchestrator.ActionOption action : actions) {
             if (action.value == 'REVOKE_PERMISSION') hasRevoke = true;
             if (action.value == 'LOCK_USER') hasLock = true;
         }
-        System.assert(hasRevoke, 'LoginAs should have REVOKE_PERMISSION action');
-        System.assert(hasLock, 'LoginAs should have LOCK_USER action');
+        Assert.isTrue(hasRevoke, 'LoginAs should have REVOKE_PERMISSION action');
+        Assert.isTrue(hasLock, 'LoginAs should have LOCK_USER action');
     }
 
     @isTest
@@ -93,7 +93,7 @@ private class RemediationOrchestratorTest {
         for (RemediationOrchestrator.ActionOption action : actions) {
             if (action.value == 'DISABLE_API_ACCESS') hasDisableAPI = true;
         }
-        System.assert(hasDisableAPI, 'API event should have DISABLE_API_ACCESS action');
+        Assert.isTrue(hasDisableAPI, 'API event should have DISABLE_API_ACCESS action');
     }
 
     @isTest
@@ -131,7 +131,7 @@ private class RemediationOrchestratorTest {
             RemediationOrchestrator.executeRemediationAction('INVALID_ACTION', null, new Map<String, Object>());
             Assert.fail( 'Should throw exception');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('Invalid'), 'Error should indicate invalid action');
+            Assert.isTrue(e.getMessage().contains('Invalid'), 'Error should indicate invalid action');
         }
         Test.stopTest();
     }

--- a/force-app/main/default/classes/RemediationSuggestionServiceTest.cls
+++ b/force-app/main/default/classes/RemediationSuggestionServiceTest.cls
@@ -81,7 +81,7 @@ private class RemediationSuggestionServiceTest {
         List<Remediation_Suggestion__c> suggestions = RemediationSuggestionService.generateSuggestions(gap.Id);
         Test.stopTest();
 
-        System.assert(suggestions.size() > 0, 'Should generate at least one suggestion');
+        Assert.isTrue(suggestions.size() > 0, 'Should generate at least one suggestion');
 
         // Verify SOX-specific suggestions
         Boolean hasAuditSuggestion = false;
@@ -95,7 +95,7 @@ private class RemediationSuggestionServiceTest {
                 hasAuditSuggestion = true;
             }
         }
-        System.assert(hasAuditSuggestion, 'Should include audit trail suggestion for SOX');
+        Assert.isTrue(hasAuditSuggestion, 'Should include audit trail suggestion for SOX');
     }
 
     @isTest
@@ -106,7 +106,7 @@ private class RemediationSuggestionServiceTest {
         List<Remediation_Suggestion__c> suggestions = RemediationSuggestionService.generateSuggestions(gap.Id);
         Test.stopTest();
 
-        System.assert(suggestions.size() > 0, 'Should generate suggestions');
+        Assert.isTrue(suggestions.size() > 0, 'Should generate suggestions');
 
         // Verify HIPAA-specific encryption suggestion
         Boolean hasEncryptionSuggestion = false;
@@ -116,7 +116,7 @@ private class RemediationSuggestionServiceTest {
                 Assert.areEqual('HIPAA', suggestion.Framework__c, 'Framework should be HIPAA');
             }
         }
-        System.assert(hasEncryptionSuggestion, 'Should include encryption suggestion for HIPAA');
+        Assert.isTrue(hasEncryptionSuggestion, 'Should include encryption suggestion for HIPAA');
     }
 
     @isTest
@@ -127,7 +127,7 @@ private class RemediationSuggestionServiceTest {
         List<Remediation_Suggestion__c> suggestions = RemediationSuggestionService.generateSuggestions(gap.Id);
         Test.stopTest();
 
-        System.assert(suggestions.size() > 0, 'Should generate suggestions');
+        Assert.isTrue(suggestions.size() > 0, 'Should generate suggestions');
 
         for (Remediation_Suggestion__c suggestion : suggestions) {
             Assert.areEqual('SOC2', suggestion.Framework__c, 'Framework should be SOC2');
@@ -142,7 +142,7 @@ private class RemediationSuggestionServiceTest {
         List<Remediation_Suggestion__c> suggestions = RemediationSuggestionService.generateSuggestions(gap.Id);
         Test.stopTest();
 
-        System.assert(suggestions.size() > 0, 'Should generate suggestions');
+        Assert.isTrue(suggestions.size() > 0, 'Should generate suggestions');
 
         // Verify privacy-specific FLS suggestion
         Boolean hasFLSSuggestion = false;
@@ -151,7 +151,7 @@ private class RemediationSuggestionServiceTest {
                 hasFLSSuggestion = true;
             }
         }
-        System.assert(hasFLSSuggestion, 'Should include FLS suggestion for GDPR');
+        Assert.isTrue(hasFLSSuggestion, 'Should include FLS suggestion for GDPR');
     }
 
     @isTest
@@ -161,7 +161,7 @@ private class RemediationSuggestionServiceTest {
             RemediationSuggestionService.generateSuggestions('a00000000000000AAA');
             Assert.fail( 'Expected exception for invalid gap ID');
         } catch (RemediationSuggestionService.RemediationException e) {
-            System.assert(e.getMessage().contains('not found'), 'Should indicate gap not found');
+            Assert.isTrue(e.getMessage().contains('not found'), 'Should indicate gap not found');
         }
         Test.stopTest();
     }
@@ -177,7 +177,7 @@ private class RemediationSuggestionServiceTest {
         List<Remediation_Suggestion__c> suggestions = RemediationSuggestionService.getSuggestions(gap.Id);
         Test.stopTest();
 
-        System.assert(suggestions.size() > 0, 'Should return generated suggestions');
+        Assert.isTrue(suggestions.size() > 0, 'Should return generated suggestions');
     }
 
     @isTest
@@ -193,7 +193,7 @@ private class RemediationSuggestionServiceTest {
             RemediationSuggestionService.getPendingSuggestions();
         Test.stopTest();
 
-        System.assert(pendingSuggestions.size() > 0, 'Should return pending suggestions');
+        Assert.isTrue(pendingSuggestions.size() > 0, 'Should return pending suggestions');
 
         for (RemediationSuggestionService.SuggestionWithGap swg : pendingSuggestions) {
             Assert.areNotEqual(null, swg.gapId, 'Gap ID should be set');
@@ -246,7 +246,7 @@ private class RemediationSuggestionServiceTest {
         Integer generated = RemediationSuggestionService.bulkGenerateSuggestions(gapIds);
         Test.stopTest();
 
-        System.assert(generated > 0, 'Should generate suggestions for multiple gaps');
+        Assert.isTrue(generated > 0, 'Should generate suggestions for multiple gaps');
 
         List<Remediation_Suggestion__c> allSuggestions = [SELECT Id FROM Remediation_Suggestion__c];
         Assert.areEqual(generated, allSuggestions.size(), 'Total suggestions should match');
@@ -288,7 +288,7 @@ private class RemediationSuggestionServiceTest {
                 Assert.areNotEqual(null, payload.get('gapId'), 'Payload should contain gapId');
             }
         }
-        System.assert(foundAutoRemediation, 'Should have at least one auto-remediable suggestion');
+        Assert.isTrue(foundAutoRemediation, 'Should have at least one auto-remediable suggestion');
     }
 
     @isTest
@@ -300,8 +300,8 @@ private class RemediationSuggestionServiceTest {
         Test.stopTest();
 
         for (Remediation_Suggestion__c suggestion : suggestions) {
-            System.assert(suggestion.Confidence_Score__c >= 0, 'Confidence should be >= 0');
-            System.assert(suggestion.Confidence_Score__c <= 1, 'Confidence should be <= 1');
+            Assert.isTrue(suggestion.Confidence_Score__c >= 0, 'Confidence should be >= 0');
+            Assert.isTrue(suggestion.Confidence_Score__c <= 1, 'Confidence should be <= 1');
         }
     }
 
@@ -313,7 +313,7 @@ private class RemediationSuggestionServiceTest {
         List<Remediation_Suggestion__c> suggestions = RemediationSuggestionService.generateSuggestions(gap.Id);
         Test.stopTest();
 
-        System.assert(suggestions.size() > 0, 'Should generate suggestions even for unknown entity type');
+        Assert.isTrue(suggestions.size() > 0, 'Should generate suggestions even for unknown entity type');
 
         Boolean hasManualReview = false;
         for (Remediation_Suggestion__c suggestion : suggestions) {
@@ -321,7 +321,7 @@ private class RemediationSuggestionServiceTest {
                 hasManualReview = true;
             }
         }
-        System.assert(hasManualReview, 'Should include manual review for unknown entity type');
+        Assert.isTrue(hasManualReview, 'Should include manual review for unknown entity type');
     }
 
     @isTest

--- a/force-app/main/default/classes/RetentionEnforcementBatchTest.cls
+++ b/force-app/main/default/classes/RetentionEnforcementBatchTest.cls
@@ -25,7 +25,7 @@ private class RetentionEnforcementBatchTest {
     static void testBatchExecution() {
         // Arrange
         Integer activityCount = [SELECT COUNT() FROM Data_Processing_Activity__c];
-        System.assert(activityCount > 0, 'Test data should exist');
+        Assert.isTrue(activityCount > 0, 'Test data should exist');
 
         // Act
         Test.startTest();

--- a/force-app/main/default/classes/RetentionEnforcementSchedulerTest.cls
+++ b/force-app/main/default/classes/RetentionEnforcementSchedulerTest.cls
@@ -67,7 +67,7 @@ private class RetentionEnforcementSchedulerTest {
             WHERE JobType = 'BatchApex'
             AND ApexClass.Name = 'RetentionEnforcementBatch'
         ];
-        System.assert(jobs.size() > 0, 'Batch job should have been queued');
+        Assert.isTrue(jobs.size() > 0, 'Batch job should have been queued');
     }
 
     @isTest

--- a/force-app/main/default/classes/RootCauseAnalysisEngineTest.cls
+++ b/force-app/main/default/classes/RootCauseAnalysisEngineTest.cls
@@ -31,7 +31,7 @@ private class RootCauseAnalysisEngineTest {
         Assert.areNotEqual(null, result, 'Should return result');
         Assert.areEqual('SUCCESS', result.status, 'Status should be SUCCESS');
         Assert.areNotEqual(null, result.rootCause, 'Should have root cause');
-        System.assert(result.confidence &gt;= 0 &amp;&amp; result.confidence &lt;= 100, 'Confidence should be 0-100');
+        Assert.isTrue(result.confidence &gt;= 0 &amp;&amp; result.confidence &lt;= 100, 'Confidence should be 0-100');
     }
     
     @isTest
@@ -43,7 +43,7 @@ private class RootCauseAnalysisEngineTest {
             RootCauseAnalysisEngine.analyzeRootCause(null);
             Assert.fail( 'Should throw exception');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should mention required');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should mention required');
         }
         Test.stopTest();
     }
@@ -57,7 +57,7 @@ private class RootCauseAnalysisEngineTest {
             RootCauseAnalysisEngine.analyzeRootCause('');
             Assert.fail( 'Should throw exception');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('required'), 'Should mention required');
+            Assert.isTrue(e.getMessage().contains('required'), 'Should mention required');
         }
         Test.stopTest();
     }
@@ -71,7 +71,7 @@ private class RootCauseAnalysisEngineTest {
             RootCauseAnalysisEngine.analyzeRootCause('a0x000000000001AAA');
             Assert.fail( 'Should throw exception');
         } catch (AuraHandledException e) {
-            System.assert(e.getMessage().contains('not found'), 'Should mention not found');
+            Assert.isTrue(e.getMessage().contains('not found'), 'Should mention not found');
         }
         Test.stopTest();
     }

--- a/force-app/main/default/classes/SOC2AccessReviewServiceTest.cls
+++ b/force-app/main/default/classes/SOC2AccessReviewServiceTest.cls
@@ -127,7 +127,7 @@ public class SOC2AccessReviewServiceTest {
         Decimal score = service.getComplianceScore();
         Test.stopTest();
 
-        System.assert(score >= 0 && score <= 100, 'Score should be between 0 and 100');
+        Assert.isTrue(score >= 0 && score <= 100, 'Score should be between 0 and 100');
     }
 
     @isTest

--- a/force-app/main/default/classes/SOC2ChangeManagementServiceTest.cls
+++ b/force-app/main/default/classes/SOC2ChangeManagementServiceTest.cls
@@ -48,7 +48,7 @@ public class SOC2ChangeManagementServiceTest {
         Assert.areNotEqual(null, result, 'Result should not be null');
         Assert.areNotEqual(null, result.evaluationDate, 'Evaluation date should be set');
         Assert.areNotEqual(null, result.controlResults, 'Control results should not be null');
-        System.assert(result.controlResults.size() > 0, 'Should have control results');
+        Assert.isTrue(result.controlResults.size() > 0, 'Should have control results');
     }
 
     @isTest
@@ -59,7 +59,7 @@ public class SOC2ChangeManagementServiceTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, changes, 'Changes list should not be null');
-        System.assert(changes.size() > 0, 'Should find unauthorized changes from test data');
+        Assert.isTrue(changes.size() > 0, 'Should find unauthorized changes from test data');
     }
 
     @isTest
@@ -98,7 +98,7 @@ public class SOC2ChangeManagementServiceTest {
             SOC2ChangeManagementService.linkChangeToTicket(change.Id, '');
             Assert.fail( 'Should have thrown exception');
         } catch (ComplianceServiceBase.ComplianceServiceException e) {
-            System.assert(e.getMessage().contains('blank'), 'Should mention blank ticket');
+            Assert.isTrue(e.getMessage().contains('blank'), 'Should mention blank ticket');
         }
         Test.stopTest();
     }
@@ -125,7 +125,7 @@ public class SOC2ChangeManagementServiceTest {
 
         // Verify document was created
         ContentDocument doc = [SELECT Title FROM ContentDocument WHERE Id = :docId];
-        System.assert(doc.Title.contains('SOC2_Change_Report'), 'Title should contain SOC2_Change_Report');
+        Assert.isTrue(doc.Title.contains('SOC2_Change_Report'), 'Title should contain SOC2_Change_Report');
     }
 
     @isTest
@@ -156,7 +156,7 @@ public class SOC2ChangeManagementServiceTest {
         Decimal score = service.getComplianceScore();
         Test.stopTest();
 
-        System.assert(score >= 0 && score <= 100, 'Score should be between 0 and 100');
+        Assert.isTrue(score >= 0 && score <= 100, 'Score should be between 0 and 100');
     }
 
     @isTest

--- a/force-app/main/default/classes/SOC2DataRetentionServiceTest.cls
+++ b/force-app/main/default/classes/SOC2DataRetentionServiceTest.cls
@@ -46,7 +46,7 @@ public class SOC2DataRetentionServiceTest {
         Assert.areNotEqual(null, result, 'Result should not be null');
         Assert.areNotEqual(null, result.evaluationDate, 'Evaluation date should be set');
         Assert.areNotEqual(null, result.objectResults, 'Object results should not be null');
-        System.assert(result.totalObjects > 0, 'Should evaluate at least one object');
+        Assert.isTrue(result.totalObjects > 0, 'Should evaluate at least one object');
     }
 
     @isTest
@@ -88,7 +88,7 @@ public class SOC2DataRetentionServiceTest {
         Decimal score = service.getComplianceScore();
         Test.stopTest();
 
-        System.assert(score >= 0 && score <= 100, 'Score should be between 0 and 100');
+        Assert.isTrue(score >= 0 && score <= 100, 'Score should be between 0 and 100');
     }
 
     @isTest
@@ -104,8 +104,8 @@ public class SOC2DataRetentionServiceTest {
         Decimal riskScore = service.calculateRiskScore('PERMISSION_SET', 'TestId', metadata);
         Test.stopTest();
 
-        System.assert(riskScore > 0, 'Risk score should be greater than 0');
-        System.assert(riskScore <= 10, 'Risk score should not exceed 10');
+        Assert.isTrue(riskScore > 0, 'Risk score should be greater than 0');
+        Assert.isTrue(riskScore <= 10, 'Risk score should not exceed 10');
     }
 
     @isTest

--- a/force-app/main/default/classes/SOC2IncidentResponseServiceTest.cls
+++ b/force-app/main/default/classes/SOC2IncidentResponseServiceTest.cls
@@ -74,7 +74,7 @@ public class SOC2IncidentResponseServiceTest {
 
         Assert.areNotEqual(null, assessment, 'Assessment should not be null');
         Assert.areNotEqual(null, assessment.breachId, 'Breach ID should be set');
-        System.assert(assessment.riskScore > 5.0, 'Risk score should be elevated for PHI breach');
+        Assert.isTrue(assessment.riskScore > 5.0, 'Risk score should be elevated for PHI breach');
         Assert.areEqual(true, assessment.notificationRequired, 'Notification should be required');
     }
 
@@ -93,7 +93,7 @@ public class SOC2IncidentResponseServiceTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, assessment, 'Assessment should not be null');
-        System.assert(assessment.riskScore < 7.0, 'Risk score should be lower for minor incident');
+        Assert.isTrue(assessment.riskScore < 7.0, 'Risk score should be lower for minor incident');
     }
 
     @isTest
@@ -119,7 +119,7 @@ public class SOC2IncidentResponseServiceTest {
 
         Assert.areNotEqual(null, deadline, 'Deadline should not be null');
         // Critical incidents have 1-day deadline
-        System.assert(deadline > DateTime.now(), 'Deadline should be in the future');
+        Assert.isTrue(deadline > DateTime.now(), 'Deadline should be in the future');
     }
 
     @isTest
@@ -156,7 +156,7 @@ public class SOC2IncidentResponseServiceTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, breaches, 'Breaches list should not be null');
-        System.assert(breaches.size() >= 2, 'Should have at least 2 open breaches from test data');
+        Assert.isTrue(breaches.size() >= 2, 'Should have at least 2 open breaches from test data');
     }
 
     @isTest
@@ -168,7 +168,7 @@ public class SOC2IncidentResponseServiceTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, metrics, 'Metrics should not be null');
-        System.assert(metrics.totalBreaches >= 3, 'Should have at least 3 breaches from test data');
+        Assert.isTrue(metrics.totalBreaches >= 3, 'Should have at least 3 breaches from test data');
     }
 
     @isTest
@@ -238,7 +238,7 @@ public class SOC2IncidentResponseServiceTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, metrics, 'Metrics should not be null');
-        System.assert(metrics.totalIncidents >= 3, 'Should have at least 3 incidents from test data');
+        Assert.isTrue(metrics.totalIncidents >= 3, 'Should have at least 3 incidents from test data');
     }
 
     @isTest
@@ -274,6 +274,6 @@ public class SOC2IncidentResponseServiceTest {
         List<IBreachNotificationService.BreachSummary> breaches = service.getOpenBreaches();
         Test.stopTest();
 
-        System.assert(breaches.size() >= 200, 'Should retrieve bulk incidents');
+        Assert.isTrue(breaches.size() >= 200, 'Should retrieve bulk incidents');
     }
 }

--- a/force-app/main/default/classes/SOC2ModuleTest.cls
+++ b/force-app/main/default/classes/SOC2ModuleTest.cls
@@ -63,7 +63,7 @@ private class SOC2ModuleTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, controls, 'Controls list should not be null');
-        System.assert(controls.size() > 0, 'Should have at least one control');
+        Assert.isTrue(controls.size() > 0, 'Should have at least one control');
 
         Set<String> families = new Set<String>();
         for (IComplianceModule.Control ctrl : controls) {
@@ -72,8 +72,8 @@ private class SOC2ModuleTest {
             Assert.areNotEqual(null, ctrl.name, 'Control name should not be null');
             Assert.areNotEqual(null, ctrl.severity, 'Control severity should not be null');
         }
-        System.assert(families.contains('CC6'), 'Should include CC6 (Logical/Physical Access)');
-        System.assert(families.contains('CC7'), 'Should include CC7 (System Operations)');
+        Assert.isTrue(families.contains('CC6'), 'Should include CC6 (Logical/Physical Access)');
+        Assert.isTrue(families.contains('CC7'), 'Should include CC7 (System Operations)');
     }
 
     // =============================================
@@ -90,7 +90,7 @@ private class SOC2ModuleTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, score, 'Score should not be null');
-        System.assert(score >= 0, 'Score should be >= 0');
+        Assert.isTrue(score >= 0, 'Score should be >= 0');
     }
 
     @IsTest
@@ -122,7 +122,7 @@ private class SOC2ModuleTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, score, 'Score should not be null even without evidence');
-        System.assert(score >= 0, 'Score should be non-negative');
+        Assert.isTrue(score >= 0, 'Score should be non-negative');
     }
 
     // =============================================
@@ -140,7 +140,7 @@ private class SOC2ModuleTest {
 
         Assert.areNotEqual(null, gaps, 'Gaps list should not be null');
         for (IComplianceModule.Gap gap : gaps) {
-            System.assert(gap.id.startsWith('GAP-SOC2-'), 'Gap ID should start with GAP-SOC2-');
+            Assert.isTrue(gap.id.startsWith('GAP-SOC2-'), 'Gap ID should start with GAP-SOC2-');
             Assert.areNotEqual(null, gap.controlCode, 'Gap controlCode should not be null');
             Assert.areNotEqual(null, gap.severity, 'Gap severity should not be null');
             Assert.areNotEqual(null, gap.recommendation, 'Gap recommendation should not be null');
@@ -165,7 +165,7 @@ private class SOC2ModuleTest {
         Test.stopTest();
 
         Assert.areNotEqual(null, gaps, 'Gaps list should not be null');
-        System.assert(gaps.size() > 0, 'Should identify gaps when no evidence present');
+        Assert.isTrue(gaps.size() > 0, 'Should identify gaps when no evidence present');
     }
 
     // =============================================
@@ -277,7 +277,7 @@ private class SOC2ModuleTest {
 
         Assert.areNotEqual(null, result, 'Result should not be null');
         Assert.areEqual('CC7.4', result.controlId, 'Control ID should match');
-        System.assert(result.passed, 'Incident response should pass');
+        Assert.isTrue(result.passed, 'Incident response should pass');
         Assert.areEqual(80, result.score, 'Score should be 80');
     }
 
@@ -295,7 +295,7 @@ private class SOC2ModuleTest {
 
         Assert.areNotEqual(null, result, 'Result should not be null');
         Assert.areEqual('CC8.1', result.controlId, 'Control ID should match');
-        System.assert(result.passed, 'Change management should pass');
+        Assert.isTrue(result.passed, 'Change management should pass');
         Assert.areEqual(90, result.score, 'Score should be 90');
     }
 
@@ -357,7 +357,7 @@ private class SOC2ModuleTest {
         Test.startTest();
         for (Elaro_Audit_Package__c pkg : packages) {
             Decimal score = module.calculateScore(pkg.Id);
-            System.assert(score >= 0, 'Score should be non-negative for package: ' + pkg.Id);
+            Assert.isTrue(score >= 0, 'Score should be non-negative for package: ' + pkg.Id);
 
             List<IComplianceModule.Gap> gaps = module.identifyGaps(pkg.Id);
             Assert.areNotEqual(null, gaps, 'Gaps should not be null for package: ' + pkg.Id);

--- a/force-app/main/default/classes/SchedulerErrorHandlerTest.cls
+++ b/force-app/main/default/classes/SchedulerErrorHandlerTest.cls
@@ -40,7 +40,7 @@ private class SchedulerErrorHandlerTest {
 
         Assert.areEqual(1, logs.size(), 'Should create one log record');
         Assert.areEqual('SCHEDULER_SUCCESS', logs[0].Error_Type__c, 'Should be SCHEDULER_SUCCESS type');
-        System.assert(logs[0].Error_Message__c.contains('100 records'), 'Should capture success details');
+        Assert.isTrue(logs[0].Error_Message__c.contains('100 records'), 'Should capture success details');
     }
 
     @isTest
@@ -52,7 +52,7 @@ private class SchedulerErrorHandlerTest {
 
         // Should return the configured value or the default
         Assert.areNotEqual(null, cron, 'Should return a CRON expression');
-        System.assert(cron.contains('*'), 'Should be a valid CRON expression');
+        Assert.isTrue(cron.contains('*'), 'Should be a valid CRON expression');
     }
 
     @isTest
@@ -73,7 +73,7 @@ private class SchedulerErrorHandlerTest {
         Test.stopTest();
 
         // Should return configured value (500) or default (100)
-        System.assert(batchSize > 0, 'Should return a positive batch size');
+        Assert.isTrue(batchSize > 0, 'Should return a positive batch size');
     }
 
     @isTest
@@ -137,6 +137,6 @@ private class SchedulerErrorHandlerTest {
         ];
 
         Assert.areEqual(1, errors.size(), 'Should create one error record');
-        System.assert(errors[0].Error_Message__c.length() <= 255, 'Message should be truncated to 255 chars');
+        Assert.isTrue(errors[0].Error_Message__c.length() <= 255, 'Message should be truncated to 255 chars');
     }
 }

--- a/force-app/main/default/classes/SegregationOfDutiesServiceTest.cls
+++ b/force-app/main/default/classes/SegregationOfDutiesServiceTest.cls
@@ -63,6 +63,6 @@ private class SegregationOfDutiesServiceTest {
         Test.stopTest();
         
         Assert.areNotEqual(null, result, 'Result should not be null');
-        System.assert(result.contains('remediated'), 'Result should indicate remediation');
+        Assert.isTrue(result.contains('remediated'), 'Result should indicate remediation');
     }
 }

--- a/force-app/main/default/classes/ServiceNowIntegrationTest.cls
+++ b/force-app/main/default/classes/ServiceNowIntegrationTest.cls
@@ -149,10 +149,10 @@ private class ServiceNowIntegrationTest {
             Assert.fail( 'Should have thrown exception');
         } catch (AuraHandledException e) {
             exceptionCaught = true;
-            System.assert(e.getMessage().length() > 0, 'Exception should have message');
+            Assert.isTrue(e.getMessage().length() > 0, 'Exception should have message');
         }
         Test.stopTest();
 
-        System.assert(exceptionCaught, 'Should catch AuraHandledException for 500 error');
+        Assert.isTrue(exceptionCaught, 'Should catch AuraHandledException for 500 error');
     }
 }

--- a/force-app/main/default/classes/SlackIntegrationTest.cls
+++ b/force-app/main/default/classes/SlackIntegrationTest.cls
@@ -194,6 +194,6 @@ private class SlackIntegrationTest {
 
         // Assert - Verify all 6 severity levels processed without exception
         Assert.areEqual(6, severities.size(), 'Should test all 6 severity levels');
-        System.assert(Limits.getCallouts() <= Limits.getLimitCallouts(), 'Should stay within callout limits');
+        Assert.isTrue(Limits.getCallouts() <= Limits.getLimitCallouts(), 'Should stay within callout limits');
     }
 }

--- a/force-app/main/default/classes/WeeklyScorecardSchedulerTest.cls
+++ b/force-app/main/default/classes/WeeklyScorecardSchedulerTest.cls
@@ -19,7 +19,7 @@ private class WeeklyScorecardSchedulerTest {
         
         // Assert result contains expected confirmation text
         Assert.areNotEqual(null, result, 'Schedule should return a result message');
-        System.assert(result.contains('Weekly scorecard scheduled') || result.contains('Elaro Weekly Scorecard'), 
+        Assert.isTrue(result.contains('Weekly scorecard scheduled') || result.contains('Elaro Weekly Scorecard'), 
             'Result should confirm scheduling: ' + result);
         
         // Verify job was actually scheduled
@@ -28,7 +28,7 @@ private class WeeklyScorecardSchedulerTest {
             FROM CronTrigger 
             WHERE CronJobDetail.Name LIKE 'Elaro Weekly Scorecard%'
         ];
-        System.assert(!scheduledJobs.isEmpty(), 'At least one scheduled job should exist');
+        Assert.isTrue(!scheduledJobs.isEmpty(), 'At least one scheduled job should exist');
     }
     
     /**
@@ -45,7 +45,7 @@ private class WeeklyScorecardSchedulerTest {
         Test.stopTest();
 
         // Verify Slack webhook callout completed successfully
-        System.assert(Limits.getCallouts() <= Limits.getLimitCallouts(), 'Should stay within callout limits');
+        Assert.isTrue(Limits.getCallouts() <= Limits.getLimitCallouts(), 'Should stay within callout limits');
     }
     
     /**
@@ -60,7 +60,7 @@ private class WeeklyScorecardSchedulerTest {
         Test.stopTest();
 
         // Verify Teams webhook callout completed successfully
-        System.assert(Limits.getCallouts() <= Limits.getLimitCallouts(), 'Should stay within callout limits');
+        Assert.isTrue(Limits.getCallouts() <= Limits.getLimitCallouts(), 'Should stay within callout limits');
     }
     
     /**
@@ -75,7 +75,7 @@ private class WeeklyScorecardSchedulerTest {
         Test.stopTest();
 
         // Verify both Slack and Teams webhooks were called
-        System.assert(Limits.getCallouts() <= Limits.getLimitCallouts(), 'Should stay within callout limits for both channels');
+        Assert.isTrue(Limits.getCallouts() <= Limits.getLimitCallouts(), 'Should stay within callout limits for both channels');
     }
     
     /**
@@ -119,7 +119,7 @@ private class WeeklyScorecardSchedulerTest {
         Test.stopTest();
 
         // Verify test scorecard executed successfully
-        System.assert(Limits.getCallouts() <= Limits.getLimitCallouts(), 'Should stay within callout limits');
+        Assert.isTrue(Limits.getCallouts() <= Limits.getLimitCallouts(), 'Should stay within callout limits');
     }
     
     /**
@@ -151,7 +151,7 @@ private class WeeklyScorecardSchedulerTest {
         }
         Test.stopTest();
 
-        System.assert(completedSuccessfully, 'Invalid channel should be handled gracefully without exception');
+        Assert.isTrue(completedSuccessfully, 'Invalid channel should be handled gracefully without exception');
     }
     
     /**

--- a/force-app/main/default/lwc/apiUsageDashboard/__tests__/apiUsageDashboard.test.js
+++ b/force-app/main/default/lwc/apiUsageDashboard/__tests__/apiUsageDashboard.test.js
@@ -172,7 +172,7 @@ describe("c-api-usage-dashboard", () => {
       await Promise.resolve();
       await flushPromises();
 
-      // Empty array [] evaluates to false in LWC, so if:false={rows} should be true
+      // Empty array [] evaluates to false in LWC, so lwc:else renders when rows is empty
       const message = element.shadowRoot.querySelector("p");
       expect(message).not.toBeNull();
       expect(message.textContent.trim()).toBe("No snapshots yet.");

--- a/force-app/main/default/lwc/apiUsageDashboard/apiUsageDashboard.html
+++ b/force-app/main/default/lwc/apiUsageDashboard/apiUsageDashboard.html
@@ -1,16 +1,16 @@
 <template>
   <lightning-card title="API Usage & Forecasting">
     <div class="slds-var-p-around_medium">
-      <template if:true={isLoading}>
+      <template lwc:if={isLoading}>
         <div class="slds-align_absolute-center slds-var-p-around_medium">
           <lightning-spinner alternative-text="Loading API usage data" size="medium"></lightning-spinner>
         </div>
       </template>
-      <template if:false={isLoading}>
-        <template if:true={hasRows}>
+      <template lwc:else>
+        <template lwc:if={hasRows}>
           <lightning-datatable key-field="id" data={rows} columns={columns}></lightning-datatable>
         </template>
-        <template if:false={hasRows}>
+        <template lwc:else>
           <p>No snapshots yet.</p>
         </template>
       </template>


### PR DESCRIPTION
## Summary
- Migrated all `System.assertEquals` → `Assert.areEqual`, `System.assertNotEquals` → `Assert.areNotEqual`, `System.assert(false,` → `Assert.fail`, `System.assert(` → `Assert.isTrue` across 120 test files (710 replacements)
- Migrated `if:true`/`if:false` → `lwc:if`/`lwc:else` in apiUsageDashboard component
- Zero legacy patterns remaining in entire codebase

## Verification
- 55 Jest suites, 784 tests — all passing
- ESLint — 0 errors, 0 warnings
- grep confirms zero remaining `System.assertEquals`, `System.assertNotEquals`, `System.assert(`, `if:true`, `if:false`

## Test plan
- [x] `npm run test:unit` — 784/784 passing
- [x] `npm run lint` — clean
- [x] grep verification for zero legacy patterns
- [ ] Deploy to scratch org and run Apex tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)