### PR TITLE
fix(ci): limit workflow token permissions

### DIFF
--- a/.github/workflows/elaro-ci.yml
+++ b/.github/workflows/elaro-ci.yml
@@ -10,6 +10,9 @@ env:
   NODE_VERSION: "20.19.0"
   ORG_ALIAS: "elaro-ci"
 
+permissions:
+  contents: read
+
 jobs:
   code-quality:
     runs-on: ubuntu-latest
@@ -52,6 +55,9 @@ jobs:
   security-scan:
     runs-on: ubuntu-latest
     needs: code-quality
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Add least-privilege GITHUB_TOKEN permissions to Elaro CI
- Grant security-events write only to the SARIF-uploading security scan job

## Verification
- npx prettier --check .github/workflows/elaro-ci.yml
- git diff --check