### PR TITLE
chore: refresh tooling dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ scanner-reports/
 specs/
 
 # Temporary documentation and analysis files
+/project.md
 FAILED_PRS_SUMMARY.md
 *_TEMP.md
 *_ANALYSIS.md

--- a/force-app/main/default/lwc/elaroCopilot/__tests__/elaroCopilot.test.js
+++ b/force-app/main/default/lwc/elaroCopilot/__tests__/elaroCopilot.test.js
@@ -304,6 +304,31 @@ describe("c-elaro-copilot", () => {
       const assistantMessage = element.shadowRoot.querySelector(".assistant-message");
       expect(assistantMessage).not.toBeNull();
     });
+
+    it("renders user and assistant messages without duplicate key errors", async () => {
+      const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+      const dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(1782036794238);
+
+      try {
+        const element = await createComponent();
+
+        const quickCard = element.shadowRoot.querySelector(".quick-action-card");
+        quickCard.click();
+        await flushPromises();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const duplicateKeyErrors = consoleErrorSpy.mock.calls.filter((call) =>
+          String(call[0]).includes('Duplicated "key" attribute value')
+        );
+
+        expect(duplicateKeyErrors).toHaveLength(0);
+      } finally {
+        dateNowSpy.mockRestore();
+        consoleErrorSpy.mockRestore();
+      }
+    });
   });
 
   describe("Loading State", () => {

--- a/force-app/main/default/lwc/elaroCopilot/elaroCopilot.js
+++ b/force-app/main/default/lwc/elaroCopilot/elaroCopilot.js
@@ -14,6 +14,7 @@ export default class ElaroCopilot extends LightningElement {
 
   // Debounce timer
   _debounceTimer;
+  _messageSequence = 0;
 
   @wire(getQuickCommands)
   wiredQuickCommands({ error, data }) {
@@ -189,13 +190,18 @@ export default class ElaroCopilot extends LightningElement {
     this.messages = [
       ...this.messages,
       {
-        id: Date.now(),
+        id: this.createMessageId(),
         role: role,
         content: content,
         timestamp: new Date(),
         copilotResponse: copilotResponse,
       },
     ];
+  }
+
+  createMessageId() {
+    this._messageSequence += 1;
+    return `${Date.now()}-${this._messageSequence}`;
   }
 
   scrollToBottom() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.29.7",
-        "@babel/eslint-parser": "^7.28.5",
+        "@babel/eslint-parser": "^7.29.7",
         "@eslint/js": "^9.39.4",
         "@lwc/eslint-plugin-lwc": "^3.5.0",
         "@salesforce/eslint-config-lwc": "^4.1.2",
@@ -23,7 +23,7 @@
         "jest": "^29.7.0",
         "jest-axe": "^10.0.0",
         "lint-staged": "16.4.0",
-        "prettier": "^3.8.3"
+        "prettier": "^3.8.4"
       },
       "engines": {
         "node": ">=20.19.0",
@@ -94,9 +94,9 @@
       }
     },
     "node_modules/@babel/eslint-parser": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.28.6.tgz",
-      "integrity": "sha512-QGmsKi2PBO/MHSQk+AAgA9R6OHQr+VqnniFE0eMWZcVcfBZoA2dKn2hUsl3Csg/Plt9opRUWdY7//VXsrIlEiA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.29.7.tgz",
+      "integrity": "sha512-zxt+UJTOMKvUt3yOg+D58MLuz334pHp93qifMFcjIIO+9hN6t+ufw2gi7vDPMpxvfnHRR+3VVXvIjineCcgyXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2226,9 +2226,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3431,9 +3431,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4505,13 +4505,13 @@
       "license": "MIT"
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6371,9 +6371,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -6550,12 +6550,13 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",
-    "@babel/eslint-parser": "^7.28.5",
+    "@babel/eslint-parser": "^7.29.7",
     "@eslint/js": "^9.39.4",
     "@lwc/eslint-plugin-lwc": "^3.5.0",
     "@salesforce/eslint-config-lwc": "^4.1.2",
@@ -47,7 +47,7 @@
     "jest": "^29.7.0",
     "jest-axe": "^10.0.0",
     "lint-staged": "16.4.0",
-    "prettier": "^3.8.3"
+    "prettier": "^3.8.4"
   },
   "overrides": {
     "@babel/core": "$@babel/core",

--- a/platform/package-lock.json
+++ b/platform/package-lock.json
@@ -13,8 +13,8 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@types/node": "^20.10.0",
-        "prettier": "^3.1.0",
+        "@types/node": "^20.19.43",
+        "prettier": "^3.8.4",
         "turbo": "^2.9.18",
         "typescript": "^5.3.0"
       },
@@ -552,9 +552,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
-      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1436,9 +1436,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/platform/package.json
+++ b/platform/package.json
@@ -20,8 +20,8 @@
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md}\""
   },
   "devDependencies": {
-    "@types/node": "^20.10.0",
-    "prettier": "^3.1.0",
+    "@types/node": "^20.19.43",
+    "prettier": "^3.8.4",
     "turbo": "^2.9.18",
     "typescript": "^5.3.0"
   },


### PR DESCRIPTION
## Summary
- refresh patch/minor tooling dependencies in root and platform packages
- ignore local-only /project.md so the working tree stays clean
- fix elaroCopilot same-millisecond duplicate message keys and add a regression test

## Validation
- npm run precommit
- npm audit --audit-level=low
- cd platform && npm audit --audit-level=low
- cd platform && npm run format:check
- cd platform && npm run lint
- cd platform && npm run typecheck
- cd platform && npm run test
- cd platform && npm run build