### PR TITLE
docs: add Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Elaro is a Salesforce second-generation managed package plus a separate TypeScript
+platform CLI. There are two independently developed surfaces in this repo:
+
+1. **Salesforce package** (`force-app`, `force-app-healthcheck`) — Apex + Lightning Web
+   Components. Lint, format, and LWC Jest tests run locally with no org. Deploying
+   metadata and running Apex tests require the `sf` CLI plus an authenticated Dev
+   Hub/scratch org, which are **not available in this environment** (no Salesforce
+   credentials and `sf` is not installed). Treat all `sf ...` / `org:*` / `sf:*` /
+   `test:apex` scripts as out of scope here.
+2. **Platform CLI** (`platform/`) — a Turborepo (`packages/{types,sf-client,masking,cli}`)
+   that builds the `elaro` CLI. This is the locally runnable application.
+
+The update script already runs `npm ci` (root, which also installs `platform/` deps via
+the `postinstall` hook) and creates the gitignored `specs/` directory. Standard commands
+live in `README.md`, `platform/README.md`, and `package.json` / `platform/package.json`
+scripts — prefer those instead of duplicating here.
+
+### Non-obvious gotchas
+
+- **`npm run precommit` / `npm run preflight` need a `specs/` directory.** It is
+  gitignored (see `.gitignore`), so a fresh checkout has none and `scripts/preflight.sh`
+  fails with "Missing specs/ directory". The update script creates it (`mkdir -p specs`);
+  if it is ever missing, recreate it.
+- **Platform deps are installed with `--ignore-scripts`** (root `postinstall` and
+  `platform/README.md`) to avoid an esbuild postinstall SIGKILL. The root `postinstall`
+  only installs `platform/node_modules` when it is absent, so if you change deps under
+  `platform/`, reinstall manually: `npm --prefix platform install --ignore-scripts`.
+- The first `npm ci` on a fresh VM leaves `platform/package-lock.json` modified (a benign
+  side effect of the `postinstall`'s `npm install`). Revert it with
+  `git checkout -- platform/package-lock.json` before committing.
+- **`platform/docker-compose.yml` is not runnable in this repo.** It references
+  `services/core` and `apps/web` Dockerfiles that do not exist (only `packages/*` are
+  present). Use the CLI, not docker compose.
+- **The `elaro` CLI runs fully offline.** Commands like `elaro scan` attempt an `sf apex run`
+  but catch the failure and return simulated results, so they work without an org.
+
+### Run the platform CLI
+
+```bash
+cd platform
+npm run build                                   # builds all packages in dep order
+node packages/cli/dist/index.js --help
+node packages/cli/dist/index.js scan --framework hipaa
+```
+
+### Local quality gates
+
+- Salesforce surface (from repo root): `npm run fmt:check`, `npm run lint`,
+  `npm run test:unit` (901 LWC Jest tests). `npm run precommit` chains preflight + the
+  above (needs `specs/`).
+- Platform surface (from `platform/`): `npm run build`, `npm run typecheck`,
+  `npm run lint`, `npm run test` (Vitest; no test files yet, passes with
+  `--passWithNoTests`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Sets up and verifies the development environment for Elaro, and documents durable, non-obvious startup/run guidance for future cloud agents in a new `AGENTS.md`.

This repo has two independently runnable surfaces:
- **Salesforce package** (`force-app`, `force-app-healthcheck`) — Apex + LWC. Lint/format/LWC Jest tests run locally; org deploy + Apex tests require `sf` + an authenticated org (not available here).
- **Platform CLI** (`platform/`) — Turborepo that builds the `elaro` CLI (the locally runnable app).

## What was verified

| Surface | Commands run | Result |
| --- | --- | --- |
| Root (Salesforce) | `npm run fmt:check`, `npm run lint`, `npm run test:unit` | format + lint clean, 901 LWC Jest tests pass |
| Root gate | `npm run precommit` (needs gitignored `specs/`) | passes after `mkdir -p specs` |
| Platform CLI | `npm run build`, `npm run typecheck`, `npm run lint`, `npm run test` | all pass |
| App run | `node packages/cli/dist/index.js scan --framework hipaa` | HIPAA compliance scan output produced |

## Environment setup

- Update script: `npm ci --legacy-peer-deps` (root install also installs `platform/` deps via `postinstall`) and `mkdir -p specs` (preflight requires the gitignored `specs/` dir).
- `AGENTS.md` captures non-obvious gotchas: the `specs/` requirement, `--ignore-scripts` for platform deps, the non-runnable `platform/docker-compose.yml`, and that the `elaro` CLI runs offline.

## Demo

[elaro CLI demo log](https://cursor.com/agents/bc-981aef61-ea23-41bc-bc81-7b463e2801b8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Felaro_cli_demo.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-981aef61-ea23-41bc-bc81-7b463e2801b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-981aef61-ea23-41bc-bc81-7b463e2801b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

