### PR TITLE
test(platform): close the platform test-coverage loop

### DIFF
--- a/.github/workflows/elaro-ci.yml
+++ b/.github/workflows/elaro-ci.yml
@@ -160,6 +160,10 @@ jobs:
         working-directory: platform
         run: npm run build
 
+      - name: Run Platform Tests
+        working-directory: platform
+        run: npm run test
+
       - name: Verify Platform Build Output
         run: |
           echo "Verifying platform build artifacts..."

--- a/platform/packages/masking/src/__tests__/engine.test.ts
+++ b/platform/packages/masking/src/__tests__/engine.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect } from "vitest";
+import type { MaskingPolicy, MaskingRule } from "@platform/types";
+
+import { MaskingEngine, calculateEffectivenessScore, type FieldInfo } from "../engine";
+import { POLICY_TEMPLATES } from "../index";
+
+function makePolicy(rules: MaskingRule[]): MaskingPolicy {
+  return {
+    id: "policy-1",
+    workspaceId: "ws-1",
+    name: "Test Policy",
+    version: 1,
+    rules,
+    isDefault: false,
+    createdAt: new Date("2026-01-01"),
+    updatedAt: new Date("2026-01-01"),
+  };
+}
+
+describe("MaskingEngine.maskField", () => {
+  it("applies a matching pattern rule", () => {
+    const engine = new MaskingEngine(
+      makePolicy([
+        {
+          id: "ssn",
+          matcher: { type: "pattern", fieldNameRegex: ".*SSN.*" },
+          strategy: { type: "redact", replacement: "XXX-XX-XXXX" },
+          priority: 0,
+        },
+      ])
+    );
+
+    const { masked, strategyUsed } = engine.maskField("123-45-6789", {
+      sobject: "Contact",
+      field: "SSN__c",
+    });
+
+    expect(masked).toBe("XXX-XX-XXXX");
+    expect(strategyUsed).toBe("redact");
+  });
+
+  it("returns the original value when no rule matches", () => {
+    const engine = new MaskingEngine(makePolicy([]));
+    const { masked, strategyUsed } = engine.maskField("keep-me", {
+      sobject: "Contact",
+      field: "Nickname__c",
+    });
+
+    expect(masked).toBe("keep-me");
+    expect(strategyUsed).toBeNull();
+  });
+
+  it("supports exact field matchers", () => {
+    const engine = new MaskingEngine(
+      makePolicy([
+        {
+          id: "exact",
+          matcher: { type: "exact", sobject: "Account", field: "Secret__c" },
+          strategy: { type: "redact", replacement: "***" },
+          priority: 0,
+        },
+      ])
+    );
+
+    expect(engine.maskField("v", { sobject: "Account", field: "Secret__c" }).strategyUsed).toBe(
+      "redact"
+    );
+    expect(
+      engine.maskField("v", { sobject: "Contact", field: "Secret__c" }).strategyUsed
+    ).toBeNull();
+  });
+
+  it("supports classification matchers", () => {
+    const engine = new MaskingEngine(
+      makePolicy([
+        {
+          id: "pii",
+          matcher: { type: "classification", tag: "pii" },
+          strategy: { type: "redact", replacement: "***" },
+          priority: 0,
+        },
+      ])
+    );
+
+    const info: FieldInfo = { sobject: "Contact", field: "Any__c", classification: ["pii"] };
+    expect(engine.maskField("v", info).strategyUsed).toBe("redact");
+  });
+
+  it("uses an email format hint for email data-type fields with a hash strategy", () => {
+    const engine = new MaskingEngine(
+      makePolicy([
+        {
+          id: "email",
+          matcher: { type: "data_type", sfType: "email" },
+          strategy: { type: "hash", algorithm: "sha256", deterministic: true },
+          priority: 0,
+        },
+      ])
+    );
+
+    const { masked } = engine.maskField("a@b.com", {
+      sobject: "Contact",
+      field: "Email",
+      dataType: "email",
+    });
+    expect(String(masked)).toMatch(/@masked\.example\.com$/);
+  });
+
+  it("honors rule priority (lowest number wins)", () => {
+    const engine = new MaskingEngine(
+      makePolicy([
+        {
+          id: "low-priority",
+          matcher: { type: "pattern", fieldNameRegex: ".*Data.*" },
+          strategy: { type: "redact", replacement: "[LOW]" },
+          priority: 5,
+        },
+        {
+          id: "high-priority",
+          matcher: { type: "pattern", fieldNameRegex: ".*Data.*" },
+          strategy: { type: "redact", replacement: "[HIGH]" },
+          priority: 0,
+        },
+      ])
+    );
+
+    expect(engine.maskField("x", { sobject: "Account", field: "Data__c" }).masked).toBe("[HIGH]");
+  });
+
+  it("only applies a rule when its conditions are satisfied", () => {
+    const engine = new MaskingEngine(
+      makePolicy([
+        {
+          id: "conditional",
+          matcher: { type: "pattern", fieldNameRegex: ".*Amount.*" },
+          strategy: { type: "redact", replacement: "***" },
+          priority: 0,
+          conditions: [{ field: "Country__c", operator: "equals", value: "US" }],
+        },
+      ])
+    );
+
+    expect(
+      engine.maskField("100", { sobject: "Deal", field: "Amount__c" }, { Country__c: "US" })
+        .strategyUsed
+    ).toBe("redact");
+    expect(
+      engine.maskField("100", { sobject: "Deal", field: "Amount__c" }, { Country__c: "CA" })
+        .strategyUsed
+    ).toBeNull();
+  });
+});
+
+describe("MaskingEngine record helpers", () => {
+  const engine = () =>
+    new MaskingEngine(
+      makePolicy([
+        {
+          id: "email",
+          matcher: { type: "pattern", fieldNameRegex: ".*Email.*" },
+          strategy: { type: "redact", replacement: "hidden@example.com" },
+          priority: 0,
+        },
+      ])
+    );
+
+  it("masks matching fields in a record and reports which were masked", () => {
+    const { maskedRecord, maskedFields } = engine().maskRecord(
+      "Contact",
+      { Email: "real@corp.com", Name: "Jane" },
+      new Map()
+    );
+
+    expect(maskedRecord.Email).toBe("hidden@example.com");
+    expect(maskedRecord.Name).toBe("Jane");
+    expect(maskedFields).toEqual(["Email"]);
+  });
+
+  it("aggregates counts and a per-field summary across a batch", () => {
+    const { maskedRecords, maskedFieldsCount, fieldMaskingSummary } = engine().maskRecords(
+      "Contact",
+      [
+        { Email: "a@corp.com", Name: "A" },
+        { Email: "b@corp.com", Name: "B" },
+      ],
+      new Map()
+    );
+
+    expect(maskedRecords).toHaveLength(2);
+    expect(maskedFieldsCount).toBe(2);
+    expect(fieldMaskingSummary.get("Email")).toBe(2);
+  });
+
+  it("generates a preview that skips Id and can hide originals", () => {
+    const previewHidden = engine().generatePreview(
+      "Contact",
+      [{ Id: "003", Email: "real@corp.com" }],
+      new Map()
+    );
+    const field = previewHidden.sampleRecords[0]?.fields[0];
+    expect(field?.name).toBe("Email");
+    expect(field?.original).toBeUndefined();
+    expect(field?.masked).toBe("hidden@example.com");
+
+    const previewShown = engine().generatePreview(
+      "Contact",
+      [{ Id: "003", Email: "real@corp.com" }],
+      new Map(),
+      true
+    );
+    expect(previewShown.sampleRecords[0]?.fields[0]?.original).toBe("real@corp.com");
+  });
+});
+
+describe("calculateEffectivenessScore", () => {
+  it("scores 100 when there are no PII fields", () => {
+    const result = calculateEffectivenessScore(makePolicy([]), []);
+    expect(result.score).toBe(100);
+    expect(result.gaps).toHaveLength(0);
+  });
+
+  it("reports masked coverage and gaps with suggested strategies", () => {
+    const policy = makePolicy([
+      {
+        id: "email",
+        matcher: { type: "pattern", fieldNameRegex: ".*Email.*" },
+        strategy: { type: "fake", generator: "email" },
+        priority: 0,
+      },
+    ]);
+
+    const piiFields: FieldInfo[] = [
+      { sobject: "Contact", field: "Email" },
+      { sobject: "Contact", field: "SSN__c" },
+    ];
+
+    const result = calculateEffectivenessScore(policy, piiFields);
+    expect(result.piiFieldsIdentified).toBe(2);
+    expect(result.piiFieldsMasked).toBe(1);
+    expect(result.score).toBe(50);
+    expect(result.gaps).toHaveLength(1);
+    expect(result.gaps[0]?.field).toBe("SSN__c");
+    expect(result.gaps[0]?.suggestedStrategy).toBe("redact");
+  });
+});
+
+describe("POLICY_TEMPLATES", () => {
+  it("exposes the expected built-in templates", () => {
+    expect(Object.keys(POLICY_TEMPLATES)).toEqual([
+      "PII_STANDARD",
+      "PCI_DSS",
+      "HIPAA",
+      "DETERMINISTIC",
+    ]);
+  });
+
+  it("PII_STANDARD redacts SSN with a fixed mask", () => {
+    const ssnRule = POLICY_TEMPLATES.PII_STANDARD.rules.find((r) => r.id === "ssn");
+    expect(ssnRule?.strategy).toMatchObject({ type: "redact", replacement: "XXX-XX-XXXX" });
+  });
+
+  it("drives the engine end-to-end using a template's rules", () => {
+    const engine = new MaskingEngine(
+      makePolicy(POLICY_TEMPLATES.PCI_DSS.rules as unknown as MaskingRule[])
+    );
+    const { masked, strategyUsed } = engine.maskField("4111111111111111", {
+      sobject: "Payment__c",
+      field: "Card_Number__c",
+    });
+    expect(strategyUsed).toBe("redact");
+    expect(masked).toBe("**** **** **** ****");
+  });
+});

--- a/platform/packages/masking/src/__tests__/strategies.test.ts
+++ b/platform/packages/masking/src/__tests__/strategies.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { redact, partialRedact } from "../strategies/redact";
+import { hash, hashWithFormatHint } from "../strategies/hash";
+import { fake, fakeDeterministic } from "../strategies/fake";
+import { fpeEncrypt, fpeDecrypt, registerKey, generateKey } from "../strategies/fpe";
+import {
+  tokenize,
+  detokenize,
+  initVault,
+  isToken,
+  getVaultStats,
+  clearVault,
+} from "../strategies/tokenize";
+
+describe("redact", () => {
+  it("returns the configured replacement", () => {
+    expect(redact("4111111111111111", { replacement: "****" })).toBe("****");
+  });
+
+  it("defaults to [REDACTED] when no replacement is provided", () => {
+    expect(redact("secret", {})).toBe("[REDACTED]");
+  });
+
+  it("returns an empty string for null or undefined input", () => {
+    expect(redact(null, { replacement: "x" })).toBe("");
+    expect(redact(undefined, { replacement: "x" })).toBe("");
+  });
+});
+
+describe("partialRedact", () => {
+  it("keeps the last N characters visible", () => {
+    expect(partialRedact("4111111111111111", { keepLast: 4 })).toBe("************1111");
+  });
+
+  it("keeps the first N characters visible", () => {
+    expect(partialRedact("password", { keepFirst: 2 })).toBe("pa******");
+  });
+
+  it("supports a custom mask character", () => {
+    expect(partialRedact("abcd", { keepFirst: 1, maskChar: "#" })).toBe("a###");
+  });
+
+  it("returns the original value when keep counts cover the whole string", () => {
+    expect(partialRedact("ab", { keepFirst: 1, keepLast: 1 })).toBe("ab");
+  });
+
+  it("returns an empty string for empty, null, or undefined input", () => {
+    expect(partialRedact("", { keepFirst: 2 })).toBe("");
+    expect(partialRedact(null, { keepFirst: 2 })).toBe("");
+    expect(partialRedact(undefined, { keepFirst: 2 })).toBe("");
+  });
+});
+
+describe("hash", () => {
+  it("is deterministic for the same input in deterministic mode (sha256)", () => {
+    const a = hash("patient@example.com", { algorithm: "sha256", deterministic: true });
+    const b = hash("patient@example.com", { algorithm: "sha256", deterministic: true });
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("produces different output for different inputs", () => {
+    const a = hash("alice", { algorithm: "sha256", deterministic: true });
+    const b = hash("bob", { algorithm: "sha256", deterministic: true });
+    expect(a).not.toBe(b);
+  });
+
+  it("changes output when a salt is applied", () => {
+    const unsalted = hash("value", { algorithm: "sha256", deterministic: true });
+    const salted = hash("value", { algorithm: "sha256", deterministic: true, salt: "pepper" });
+    expect(salted).not.toBe(unsalted);
+  });
+
+  it("supports the murmur3 algorithm with an 8-char hex digest", () => {
+    const a = hash("value", { algorithm: "murmur3", deterministic: true });
+    const b = hash("value", { algorithm: "murmur3", deterministic: true });
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it("returns an empty string for null or undefined input", () => {
+    expect(hash(null, { algorithm: "sha256", deterministic: true })).toBe("");
+    expect(hash(undefined, { algorithm: "sha256", deterministic: true })).toBe("");
+  });
+});
+
+describe("hashWithFormatHint", () => {
+  it("preserves an email-like shape", () => {
+    const result = hashWithFormatHint("a@b.com", {
+      algorithm: "sha256",
+      deterministic: true,
+      formatHint: "email",
+    });
+    expect(result).toMatch(/^[0-9a-f]{16}@masked\.example\.com$/);
+  });
+
+  it("preserves a phone-like shape", () => {
+    const result = hashWithFormatHint("5551234567", {
+      algorithm: "sha256",
+      deterministic: true,
+      formatHint: "phone",
+    });
+    expect(result).toMatch(/^555-[0-9a-f]{3}-[0-9a-f]{4}$/);
+  });
+
+  it("falls back to the raw hash without a format hint", () => {
+    const result = hashWithFormatHint("value", { algorithm: "sha256", deterministic: true });
+    expect(result).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("returns an empty string for null input", () => {
+    expect(hashWithFormatHint(null, { algorithm: "sha256", deterministic: true })).toBe("");
+  });
+});
+
+describe("fake", () => {
+  it("is deterministic for the same input value", () => {
+    const a = fakeDeterministic("seed-value", { generator: "name" });
+    const b = fakeDeterministic("seed-value", { generator: "name" });
+    expect(a).toBe(b);
+    expect(a.length).toBeGreaterThan(0);
+  });
+
+  it("generates an email-shaped value", () => {
+    const result = fake("x", { generator: "email", deterministic: true });
+    expect(result).toContain("@");
+  });
+
+  it("generates an SSN-shaped value", () => {
+    const result = fake("x", { generator: "ssn", deterministic: true });
+    expect(result).toMatch(/^\d{3}-\d{2}-\d{4}$/);
+  });
+
+  it("still returns a value when the input is null", () => {
+    const result = fake(null, { generator: "text" });
+    expect(typeof result).toBe("string");
+    expect(result.length).toBeGreaterThan(0);
+  });
+});
+
+describe("fpe", () => {
+  const keyId = "unit-test-key";
+
+  beforeEach(() => {
+    registerKey(keyId, Buffer.alloc(32, 7));
+  });
+
+  it("round-trips a value with format preservation", () => {
+    const original = "Abc-1234";
+    const encrypted = fpeEncrypt(original, { keyId, preserveFormat: true });
+    expect(encrypted).not.toBe(original);
+    expect(encrypted).toHaveLength(original.length);
+    // Non-alphanumeric characters are preserved in place.
+    expect(encrypted[3]).toBe("-");
+    expect(fpeDecrypt(encrypted, { keyId, preserveFormat: true })).toBe(original);
+  });
+
+  it("round-trips a value without format preservation", () => {
+    const original = "sensitive-value";
+    const encrypted = fpeEncrypt(original, { keyId, preserveFormat: false });
+    expect(encrypted).not.toBe(original);
+    expect(fpeDecrypt(encrypted, { keyId, preserveFormat: false })).toBe(original);
+  });
+
+  it("works with a passphrase-generated key", () => {
+    generateKey("generated-key", "correct horse battery staple");
+    const encrypted = fpeEncrypt("hello", { keyId: "generated-key", preserveFormat: false });
+    expect(fpeDecrypt(encrypted, { keyId: "generated-key", preserveFormat: false })).toBe("hello");
+  });
+
+  it("throws when the key is not registered", () => {
+    expect(() => fpeEncrypt("value", { keyId: "missing", preserveFormat: true })).toThrow(
+      /FPE key not found/
+    );
+  });
+
+  it("returns an empty string for empty or nullish input", () => {
+    expect(fpeEncrypt("", { keyId, preserveFormat: true })).toBe("");
+    expect(fpeEncrypt(null, { keyId, preserveFormat: true })).toBe("");
+  });
+});
+
+describe("tokenize", () => {
+  const vaultRef = "unit-test-vault";
+
+  beforeEach(() => {
+    initVault(vaultRef);
+    clearVault(vaultRef);
+  });
+
+  it("throws when the vault is not initialized", () => {
+    expect(() => tokenize("value", { vaultRef: "never-initialized" })).toThrow(
+      /Token vault not initialized/
+    );
+  });
+
+  it("produces a recognizable token and detokenizes back to the original", () => {
+    const token = tokenize("john.doe@example.com", { vaultRef });
+    expect(isToken(token)).toBe(true);
+    expect(detokenize(token, { vaultRef })).toBe("john.doe@example.com");
+  });
+
+  it("returns the same token for the same value (referential consistency)", () => {
+    const first = tokenize("repeat", { vaultRef });
+    const second = tokenize("repeat", { vaultRef });
+    expect(first).toBe(second);
+    expect(getVaultStats(vaultRef).tokenCount).toBe(1);
+  });
+
+  it("returns null when detokenizing an unknown token", () => {
+    expect(detokenize("TOK_UNKNOWNUNKNOWNUNKNOWN00", { vaultRef })).toBeNull();
+  });
+
+  it("reports vault stats and initialization state", () => {
+    tokenize("a", { vaultRef });
+    tokenize("b", { vaultRef });
+    const stats = getVaultStats(vaultRef);
+    expect(stats.initialized).toBe(true);
+    expect(stats.tokenCount).toBe(2);
+    expect(getVaultStats("does-not-exist").initialized).toBe(false);
+  });
+
+  it("returns an empty string for null input", () => {
+    expect(tokenize(null, { vaultRef })).toBe("");
+  });
+});
+
+describe("isToken", () => {
+  it("recognizes valid token format only", () => {
+    expect(isToken("TOK_ABCDEFGHIJKLMNOPQRSTUVWX")).toBe(true);
+    expect(isToken("not-a-token")).toBe(false);
+    expect(isToken("TOK_short")).toBe(false);
+  });
+});

--- a/platform/packages/sf-client/src/__tests__/auth.test.ts
+++ b/platform/packages/sf-client/src/__tests__/auth.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+
+import { validateJwtConfig, AuthenticationError } from "../auth/jwt";
+import { buildAuthorizationUrl, OAuthError } from "../auth/oauth";
+
+const VALID_PEM = "-----BEGIN PRIVATE KEY-----\nMIIfake\n-----END PRIVATE KEY-----";
+
+describe("validateJwtConfig", () => {
+  it("returns no errors for a complete, valid config", () => {
+    const errors = validateJwtConfig({
+      clientId: "abc",
+      username: "user@example.com",
+      privateKey: VALID_PEM,
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it("flags a missing clientId", () => {
+    const errors = validateJwtConfig({ clientId: "", username: "u", privateKey: VALID_PEM });
+    expect(errors).toContain("clientId is required");
+  });
+
+  it("flags a missing username", () => {
+    const errors = validateJwtConfig({ clientId: "a", username: "", privateKey: VALID_PEM });
+    expect(errors).toContain("username is required");
+  });
+
+  it("flags a missing private key", () => {
+    const errors = validateJwtConfig({ clientId: "a", username: "u", privateKey: "" });
+    expect(errors).toContain("privateKey is required");
+  });
+
+  it("flags a private key that is not PEM-formatted", () => {
+    const errors = validateJwtConfig({ clientId: "a", username: "u", privateKey: "not-a-key" });
+    expect(errors).toContain("privateKey must be a valid PEM-formatted RSA private key");
+  });
+
+  it("accumulates multiple errors at once", () => {
+    const errors = validateJwtConfig({ clientId: "", username: "", privateKey: "" });
+    expect(errors).toHaveLength(3);
+  });
+});
+
+describe("buildAuthorizationUrl", () => {
+  it("builds a URL with defaults", () => {
+    const url = new URL(
+      buildAuthorizationUrl({
+        clientId: "myclient",
+        clientSecret: "secret",
+        redirectUri: "https://app.example.com/callback",
+      })
+    );
+
+    expect(url.origin + url.pathname).toBe(
+      "https://login.salesforce.com/services/oauth2/authorize"
+    );
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("client_id")).toBe("myclient");
+    expect(url.searchParams.get("redirect_uri")).toBe("https://app.example.com/callback");
+    expect(url.searchParams.get("scope")).toBe("api refresh_token full");
+  });
+
+  it("honors custom scopes, login URL, and state", () => {
+    const url = new URL(
+      buildAuthorizationUrl(
+        {
+          clientId: "c",
+          clientSecret: "s",
+          redirectUri: "https://cb",
+          loginUrl: "https://test.salesforce.com",
+          scopes: ["api", "web"],
+        },
+        "xyz-state"
+      )
+    );
+
+    expect(url.origin).toBe("https://test.salesforce.com");
+    expect(url.searchParams.get("scope")).toBe("api web");
+    expect(url.searchParams.get("state")).toBe("xyz-state");
+  });
+
+  it("omits state when it is not provided", () => {
+    const url = new URL(
+      buildAuthorizationUrl({ clientId: "c", clientSecret: "s", redirectUri: "https://cb" })
+    );
+    expect(url.searchParams.has("state")).toBe(false);
+  });
+});
+
+describe("auth error types", () => {
+  it("expose named error classes", () => {
+    expect(new AuthenticationError("boom").name).toBe("AuthenticationError");
+    expect(new OAuthError("boom").name).toBe("OAuthError");
+    expect(new AuthenticationError("boom")).toBeInstanceOf(Error);
+  });
+});

--- a/platform/packages/sf-client/tsconfig.json
+++ b/platform/packages/sf-client/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/__tests__"]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Closes the one outstanding, org-independent gap from the backlog: the platform packages previously passed CI only via `vitest run --passWithNoTests` (flagged in `docs/techdebt/techdebt-2026-06-20.md` as "real tests should be added before the platform CLI becomes customer-facing"). This adds a real, deterministic Vitest suite for the pure-logic packages and wires it into CI so the loop is enforced automatically.

No org auth, network, or Salesforce CLI is required — everything runs locally and in CI.

## What changed

- **`@platform/masking`** — 48 tests across strategies and the engine:
  - `redact` / `partialRedact`, `hash` (sha256 + murmur3, determinism, salt) and `hashWithFormatHint`, `fake` (deterministic seeding, email/SSN shapes), `fpe` (format-preserving + AES round-trips, missing-key error), `tokenize` (vault round-trip, referential consistency, `isToken`).
  - `MaskingEngine` field/record/batch masking, all matcher types (exact/pattern/data_type/classification), priority ordering, conditional rules, preview generation, `calculateEffectivenessScore`, and `POLICY_TEMPLATES` driving the engine end-to-end.
- **`@platform/sf-client`** — 10 tests for the pure auth helpers `validateJwtConfig` (all validation branches) and `buildAuthorizationUrl` (defaults, custom scopes/login URL/state), plus error-class identity. Excluded `src/__tests__` from the package build, matching the existing `masking` convention.
- **CI** — added a "Run Platform Tests" step to the `cli-build` job so `platform` tests run on every push/PR.

## Verification

- ✅ `cd platform && npm run test` → **58 tests pass** (masking 48, sf-client 10; cli still `passWithNoTests`)
- ✅ `cd platform && npm run typecheck`
- ✅ `cd platform && npm run lint`
- ✅ `cd platform && npm run format:check`
- ✅ `cd platform && npm run build`

[platform vitest run output](https://cursor.com/agents/bc-981aef61-ea23-41bc-bc81-7b463e2801b8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fplatform_vitest_run.log)

## Out of scope

The remaining backlog items (org deploy/Apex coverage, `ProtectSensitiveData` dispositions, namespace/packaging) all require restored Salesforce CLI auth or are already documented, so they can't be turned into a self-contained loop here.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-981aef61-ea23-41bc-bc81-7b463e2801b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-981aef61-ea23-41bc-bc81-7b463e2801b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

