### PR TITLE
audit: elaro-audit-loop RUN 2026-07-08, STATIC-GREEN exit

### DIFF
--- a/audits/AUDIT-STATE.md
+++ b/audits/AUDIT-STATE.md
@@ -1,0 +1,58 @@
+# Elaro Audit Loop State
+
+This file is machine-parseable per-run state for /elaro-audit-loop. Status vocabulary is fixed:
+OPEN, IN-PROGRESS, FIXED, WAIVED, PENDING-WAIVER, BLOCKED, N/A.
+
+<!-- BEGIN RUN 2026-07-08 -->
+iteration: 1 / 10          budget_spent: 0h 12m
+branch: claude/elaro-audit-loop-mtzgpb  head: 4d0cec46e151f1225a419c81de02f547ff16969b
+gates: scanner=GREEN  checklist=GREEN  tests=BLOCKED  validate=BLOCKED
+scope: repo (working tree at /home/user/Elaro)
+note: loop template prescribes branch audit-loop/20260708; session harness mandates
+claude/elaro-audit-loop-mtzgpb and forbids pushing elsewhere. Harness branch used.
+companion: /elaro-audit not present in this environment; condensed gate list fallback used.
+
+| ID | Sev | Status | Attempts | Evidence |
+| T-001 | Crit | N/A | 1 | Tooling artifact, not a code finding: eslint engine UninstantiableEngineError because repo node_modules were absent in fresh container. Resolved by npm@11 install (npm 10.9.7 fails on "$@babel/core" override reference; see PROPOSALS P-001). Re-scan receipt: receipts/2026-07-08-iter1.md, all 4 engines executed. |
+| E-001 | Mod | N/A | 1 | FP: ProtectSensitiveData on Deployment_Job__c.Tests_Passed__c, type Number (test count). FALSE-POSITIVES.md #1 |
+| E-002 | Mod | N/A | 1 | FP: Elaro_Evidence_Anchor__c.Content_Hash__c, Text(64) SHA-256 integrity digest, non-reversible, not a credential. FALSE-POSITIVES.md #2 |
+| E-003 | Mod | N/A | 1 | FP: Security_Incident__c.Assigned_To__c, Lookup(User) assignment field. FALSE-POSITIVES.md #3 |
+| E-004 | Mod | N/A | 1 | FP: Third_Party_Recipient__c.DPA_Signed__c, Checkbox. FALSE-POSITIVES.md #4 |
+| E-005 | Mod | N/A | 1 | FP: Trust_Center_Link__c.Access_Count__c, Number telemetry. FALSE-POSITIVES.md #5 |
+| E-006 | Mod | N/A | 1 | FP: Trust_Center_Link__c.Access_Tier__c, Picklist. FALSE-POSITIVES.md #6 |
+| E-007 | Mod | N/A | 1 | FP: Trust_Center_Link__c.Last_Accessed_Date__c, DateTime. FALSE-POSITIVES.md #7 |
+| E-008 | Mod | N/A | 1 | Accepted design: Trust_Center_Link__c.Link_Token__c IS a capability token, by design. 128-bit crypto-random (Crypto.generateAesKey), unique, expiring, revocable; validated via TrustCenterLinkService.validateToken (WITH USER_MODE, expiry + Is_Active checks); guest surface TrustCenterGuestController is with sharing. FALSE-POSITIVES.md #8 |
+| E-009 | Mod | N/A | 1 | FP: Trust_Center_View__c.Certification_Status__c, Picklist. FALSE-POSITIVES.md #9 |
+| E-010 | Mod | N/A | 1 | FP: Trust_Center_View__c.Is_Public__c, Checkbox. FALSE-POSITIVES.md #10 |
+| E-011 | Mod | N/A | 1 | FP: Workflow_Execution__c.Rules_Passed__c, Number. FALSE-POSITIVES.md #11 |
+| G-TESTS | - | BLOCKED | 1 | Apex tests + 90% coverage gate requires org auth. sf org list: "No Orgs found" (receipt, 2026-07-08 03:42 UTC). No {ORG_ALIAS} provided. Supplementary: local LWC Jest suite 64/64 suites, 901/901 tests PASS (receipts/2026-07-08-iter1.md). |
+| G-VALIDATE | - | BLOCKED | 1 | sf project deploy validate for both 2GP surfaces requires org auth. Same receipt: no authenticated orgs. |
+
+## CHANGELOG
+- 2026-07-08 iter1: T-001 closed as tooling artifact; full 4-engine re-scan clean of Critical/High (receipts/2026-07-08-iter1.md).
+- 2026-07-08 iter1: E-001..E-011 dispositioned N/A with per-field type evidence (FALSE-POSITIVES.md, receipts/2026-07-08-iter1.md).
+- 2026-07-08 iter1: G-TESTS, G-VALIDATE marked BLOCKED-ON-AUTH; loop cannot fake org results.
+
+## EXIT REPORT (RUN 2026-07-08)
+terminal_state: STATIC-GREEN
+- Gate scanner: GREEN. sf code-analyzer 5.13.0, rule selectors AppExchange + Recommended:Security, workspaces force-app and force-app-healthcheck, engines retire-js, regex, pmd, eslint all executed. 0 Critical, 0 High. 11 Moderate, all dispositioned with evidence (net of waivers: no waivers required).
+- Gate checklist: GREEN. Ledger has zero OPEN and zero IN-PROGRESS items; every item FIXED, N/A-justified, or BLOCKED on an org gate.
+- Gate tests/coverage: BLOCKED-ON-AUTH. Not run, not assumed.
+- Gate validate: BLOCKED-ON-AUTH. Not run, not assumed.
+iterations_used: 1 of 10; budget_spent: ~15m of 4h
+findings: fixed=0 waived=0 pending-waiver=0 blocked=2(org gates) na_justified=12
+false_positive_documentation: audits/FALSE-POSITIVES.md complete for all 11 scanner Moderates, submission-ready.
+commit_range: single commit on claude/elaro-audit-loop-mtzgpb (audit artifacts only; no package code changes were required).
+
+### Commands to finish once org auth lands (JWT path, G-E2)
+```
+sf org login jwt --client-id <CONNECTED_APP_ID> --jwt-key-file <server.key> --username <USER> --alias ELARO_VALIDATION --set-default
+sf apex run test -o ELARO_VALIDATION --code-coverage --result-format human --wait 30
+sf project deploy validate --source-dir force-app -o ELARO_VALIDATION --test-level RunLocalTests --wait 60
+sf project deploy validate --source-dir force-app-healthcheck -o ELARO_VALIDATION --wait 60
+```
+
+### Drift Log candidate rows (for Derick to file; not written to Mem)
+- G-TESTS BLOCKED-ON-AUTH: no authenticated org in remote container; JWT secret provisioning needed for closed-loop FULL-GREEN runs.
+- G-VALIDATE BLOCKED-ON-AUTH: same root cause.
+<!-- END RUN -->

--- a/audits/FALSE-POSITIVES.md
+++ b/audits/FALSE-POSITIVES.md
@@ -1,0 +1,23 @@
+# Scanner False-Positive Documentation for AppExchange Submission
+
+Scanner: sf code-analyzer 5.13.0, rule selectors `AppExchange` + `Recommended:Security`,
+workspaces `force-app` and `force-app-healthcheck`. Rule: PMD `ProtectSensitiveData`
+(Moderate). The rule flags custom fields whose names match sensitive-data heuristics
+("token", "passed", "signed", "hash", "access", "tier", "status", "public").
+Each flagged field was inspected on 2026-07-08 at commit 4d0cec4. None stores a
+credential, secret, or regulated personal data. No `<visibleLines>`/encryption change
+is warranted; dispositions below are offered as review documentation.
+
+| # | Field | Declared type | Disposition |
+|---|-------|---------------|-------------|
+| 1 | Deployment_Job__c.Tests_Passed__c | Number | Count of passing Apex tests in a deployment job. Not a password; name matches "pass" heuristic. |
+| 2 | Elaro_Evidence_Anchor__c.Content_Hash__c | Text(64) | SHA-256 hex digest anchoring evidence integrity. One-way digest, not a key or credential. |
+| 3 | Security_Incident__c.Assigned_To__c | Lookup(User) | Incident assignee reference. Standard ownership pattern. |
+| 4 | Third_Party_Recipient__c.DPA_Signed__c | Checkbox | Boolean flag that a data processing agreement is signed. Stores no signature material. |
+| 5 | Trust_Center_Link__c.Access_Count__c | Number | View counter telemetry. |
+| 6 | Trust_Center_Link__c.Access_Tier__c | Picklist | Tier label (Public, Email_Gated, NDA_Required). |
+| 7 | Trust_Center_Link__c.Last_Accessed_Date__c | DateTime | Access timestamp telemetry. |
+| 8 | Trust_Center_Link__c.Link_Token__c | Text(36), unique, external ID | True positive detection, accepted by design. This is a shareable-link capability token: 128-bit value from Crypto.generateAesKey formatted as UUID (TrustCenterLinkService.generateUuid, force-app/main/default/classes/TrustCenterLinkService.cls:140). Validation enforces existence, Is_Active__c, and Expiration_Date__c under WITH USER_MODE (TrustCenterLinkService.cls:56-82); links are revocable (revokeLink); the guest-facing controller TrustCenterGuestController is declared `with sharing`. Equivalent to standard document-share-link tokens; storing it in plaintext is required for lookup and it grants only tier-scoped read access to Trust Center content. |
+| 9 | Trust_Center_View__c.Certification_Status__c | Picklist | Certification display status. |
+| 10 | Trust_Center_View__c.Is_Public__c | Checkbox | Visibility flag. |
+| 11 | Workflow_Execution__c.Rules_Passed__c | Number | Count of passing workflow rules. |

--- a/audits/PENDING-WAIVERS.md
+++ b/audits/PENDING-WAIVERS.md
@@ -1,0 +1,7 @@
+# Pending Waivers (drafts for Derick)
+
+Drafted by the audit loop for Derick to review. Items become WAIVED only when Derick
+moves them into audits/WAIVERS.md himself; the loop never writes that file.
+
+(none this run: RUN 2026-07-08 required no waivers; all scanner Moderates were
+dispositioned as documented false positives or accepted design, see FALSE-POSITIVES.md)

--- a/audits/PROPOSALS.md
+++ b/audits/PROPOSALS.md
@@ -1,0 +1,23 @@
+# Loop Improvement Proposals
+
+Observed by the audit loop; never self-applied. Derick reviews and applies.
+
+## RUN 2026-07-08
+- P-001 (tooling): package.json `engines.npm` says ">=10.0.0" but the overrides entry
+  `"@babel/core": "$@babel/core"` fails on npm 10.9.7 with "Unable to resolve reference
+  $@babel/core"; npm 11 resolves it fine. Either bump engines.npm to ">=11" or replace
+  the `$` reference with the concrete spec "^7.29.7" so fresh CI/containers on npm 10
+  can install.
+- P-002 (docs accuracy): TrustCenterLinkService.generateUuid doc and the
+  Trust_Center_Link__c.Link_Token__c field description both say the token comes from
+  Crypto.getRandomUUID(), but the implementation derives it from Crypto.generateAesKey(128)
+  (TrustCenterLinkService.cls:140-146). Align the comments with the implementation (or
+  switch to Crypto.getRandomUUID() if org API version allows) so security review reads
+  consistently.
+- P-003 (loop rule): the loop template's working-branch rule (audit-loop/YYYYMMDD)
+  can conflict with harness-designated branches in remote sessions. Suggest the template
+  say: use the harness-designated branch when one is mandated, record the deviation in
+  AUDIT-STATE.md.
+- P-004 (scanner hygiene): consider adding a code-analyzer.yml disposition or a
+  documented-suppression list for the 11 recurring ProtectSensitiveData Moderates so
+  future runs diff against a known-FP baseline instead of re-triaging.

--- a/audits/receipts/2026-07-08-iter1.md
+++ b/audits/receipts/2026-07-08-iter1.md
@@ -1,0 +1,54 @@
+# Receipts, RUN 2026-07-08, iteration 1
+
+## Environment
+- date: Wed Jul 8 03:40:48 UTC 2026
+- branch: claude/elaro-audit-loop-mtzgpb
+- head: 4d0cec46e151f1225a419c81de02f547ff16969b (Merge pull request #236)
+- sf CLI: @salesforce/cli/2.141.6 linux-x64 node-v22.22.2
+- code-analyzer plugin: 5.13.0
+
+## Receipt 1: initial scan (03:42 UTC)
+Command: sf code-analyzer run --rule-selector AppExchange --rule-selector Recommended:Security --workspace force-app --workspace force-app-healthcheck
+Result: 12 violations across 11 files; 1 Critical (eslint engine UninstantiableEngineError,
+ERR_MODULE_NOT_FOUND @eslint/js: repo node_modules absent in fresh container), 11 Moderate
+(all PMD ProtectSensitiveData on field metadata). Engines executed: retire-js, regex, pmd.
+
+## Receipt 2: dependency install
+- npm 10.9.7 `npm ci` and `npm install` both fail: "Unable to resolve reference $@babel/core" (PROPOSALS P-001)
+- `npx -y npm@11 install`: success, 0 vulnerabilities.
+
+## Receipt 3: full re-scan, all engines (03:45 UTC)
+Same command as Receipt 1.
+Result: 11 violations across 11 files; 0 Critical, 0 High, 11 Moderate (PMD
+ProtectSensitiveData). Engines executed: retire-js, regex, pmd, eslint.
+Scanner gate: GREEN (zero Critical, zero High, no waivers needed).
+Violations (severity | rule | file):
+1. Mod | ProtectSensitiveData | force-app/main/default/objects/Deployment_Job__c/fields/Tests_Passed__c.field-meta.xml
+2. Mod | ProtectSensitiveData | force-app/main/default/objects/Elaro_Evidence_Anchor__c/fields/Content_Hash__c.field-meta.xml
+3. Mod | ProtectSensitiveData | force-app/main/default/objects/Security_Incident__c/fields/Assigned_To__c.field-meta.xml
+4. Mod | ProtectSensitiveData | force-app/main/default/objects/Third_Party_Recipient__c/fields/DPA_Signed__c.field-meta.xml
+5. Mod | ProtectSensitiveData | force-app/main/default/objects/Trust_Center_Link__c/fields/Access_Count__c.field-meta.xml
+6. Mod | ProtectSensitiveData | force-app/main/default/objects/Trust_Center_Link__c/fields/Access_Tier__c.field-meta.xml
+7. Mod | ProtectSensitiveData | force-app/main/default/objects/Trust_Center_Link__c/fields/Last_Accessed_Date__c.field-meta.xml
+8. Mod | ProtectSensitiveData | force-app/main/default/objects/Trust_Center_Link__c/fields/Link_Token__c.field-meta.xml
+9. Mod | ProtectSensitiveData | force-app/main/default/objects/Trust_Center_View__c/fields/Certification_Status__c.field-meta.xml
+10. Mod | ProtectSensitiveData | force-app/main/default/objects/Trust_Center_View__c/fields/Is_Public__c.field-meta.xml
+11. Mod | ProtectSensitiveData | force-app/main/default/objects/Workflow_Execution__c/fields/Rules_Passed__c.field-meta.xml
+
+## Receipt 4: local LWC Jest suite (03:46 UTC)
+Command: npm run test:unit
+Result: Test Suites 64 passed / 64 total; Tests 901 passed / 901 total.
+(Supplementary evidence only; the Apex test + coverage gate remains BLOCKED-ON-AUTH.)
+
+## Receipt 5: org auth check (03:42 UTC)
+Command: sf org list
+Result: "No Orgs found." Gates tests/coverage and validate are BLOCKED-ON-AUTH.
+No {ORG_ALIAS} was provided to this run and no credentials exist in the container.
+No org was targeted or mutated.
+
+## Receipt 6: cross-reference validation of E-008 (Link_Token__c)
+- force-app/main/default/classes/TrustCenterLinkService.cls:11 `public inherited sharing class`
+- :56-82 validateToken: WITH USER_MODE, Is_Active__c + Expiration_Date__c checks
+- :140-146 generateUuid: Crypto.generateAesKey(128) formatted as UUID (128-bit entropy)
+- force-app/main/default/classes/TrustCenterGuestController.cls:19 `public with sharing class`
+- Field: Text(36), required, unique, externalId (Link_Token__c.field-meta.xml)


### PR DESCRIPTION
## Summary
Closed audit-fix-verify loop run (`/elaro-audit-loop`, repo scope) on the working tree at `4d0cec4`. Terminal state: **STATIC-GREEN**. No package code changes were required; this PR adds the audit ledger, receipts, false-positive documentation, and proposals under `audits/`.

## Gate results
- **Scanner: GREEN.** `sf code-analyzer` 5.13.0, `--rule-selector AppExchange --rule-selector Recommended:Security`, workspaces `force-app` + `force-app-healthcheck`, all 4 engines (pmd, eslint, regex, retire-js) executed. 0 Critical, 0 High. 11 Moderate PMD `ProtectSensitiveData` findings, each dispositioned with per-field type evidence in `audits/FALSE-POSITIVES.md`.
- **Checklist ledger: GREEN.** Zero OPEN or IN-PROGRESS items (`audits/AUDIT-STATE.md`).
- **Apex tests + coverage: BLOCKED-ON-AUTH.** No authenticated org in the container ("No Orgs found"), so this gate was not run and is not assumed green. Supplementary: local LWC Jest suite passes 901/901 tests across 64 suites.
- **Deploy validate (both 2GP surfaces): BLOCKED-ON-AUTH.** Same root cause. Ready-to-run JWT commands are listed in the exit report inside `audits/AUDIT-STATE.md`.

## Notable dispositions
- The single Critical from the first scan was the eslint engine failing to instantiate (missing `node_modules` in a fresh container), a tooling artifact, not a code finding. After installing dev dependencies, the full-engine re-scan is clean of Critical/High.
- `Trust_Center_Link__c.Link_Token__c` is a true detection accepted by design: a 128-bit crypto-random, expiring, revocable share-link capability token validated under `WITH USER_MODE` with a `with sharing` guest controller. Documented for security review in `audits/FALSE-POSITIVES.md` #8.
- `npm ci`/`npm install` fail on npm 10.9.7 due to the `"$@babel/core"` override reference (works on npm 11). Proposal P-001 in `audits/PROPOSALS.md` suggests bumping `engines.npm` or using a concrete spec.

## Waivers
None required this run. `audits/PENDING-WAIVERS.md` is empty; `audits/WAIVERS.md` was not present and was not created (owner-only file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2Nc64XyiqHvBzzvxiEx4f

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2Nc64XyiqHvBzzvxiEx4f)_